### PR TITLE
Add window watcher code & call placeholder function on window load

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const Cu = Components.utils;
+const {utils: Cu} = Components;
 
 Cu.import('resource://gre/modules/XPCOMUtils.jsm');
 XPCOMUtils.defineLazyModuleGetter(this, 'UniversalSearch',
-  'chrome://usearch-lib/universal-search.js');
+  'chrome://usearch-lib/content/universal-search.js');
 
 function startup(data, reason) {
   UniversalSearch.load();  

--- a/lib/universal-search.js
+++ b/lib/universal-search.js
@@ -2,13 +2,34 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const {utils: Cu} = Components;
+
+Cu.import('resource://gre/modules/XPCOMUtils.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'console',
+  'resource://gre/modules/Console.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'WindowWatcher',
+  'chrome://usearch-lib/content/window-watcher.js');
+
 const EXPORTED_SYMBOLS = ['UniversalSearch'];
 
 function Search() {}
 
 Search.prototype = {
-  load: function() {},
-  unload: function() {}
+  load: function() {
+    WindowWatcher.start(this.loadIntoWindow, this.unloadFromWindow, this.onError);
+  },
+
+  unload: function() {
+    WindowWatcher.stop();
+  },
+
+  loadIntoWindow: function(win) {},
+
+  unloadFromWindow: function(win) {},
+
+  onError: function(msg) {
+    console.error(msg);
+  }
 };
 
 // Expose a singleton, since we only need one of these for the add-on.

--- a/lib/window-watcher.js
+++ b/lib/window-watcher.js
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const {utils: Cu} = Components;
+
+Cu.import('resource://gre/modules/XPCOMUtils.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'Services',
+  'resource://gre/modules/Services.jsm');
+
+const EXPORTED_SYMBOLS = ['WindowWatcher'];
+
+const ww = {
+  _isActive: false,
+
+  _loadCallback: null,
+
+  _unloadCallback: null,
+
+  _errback: null,
+
+  start: function(loadCallback, unloadCallback, errback) {
+    if (ww._isActive) {
+      ww._onError('called start, but WindowWatcher was already running');
+      return;
+    }
+
+    ww._isActive = true;
+    ww._loadCallback = loadCallback;
+    ww._unloadCallback = unloadCallback;
+    ww._errback = errback;
+
+    const windows = Services.wm.getEnumerator('navigator:browser');
+    while (windows.hasMoreElements()) {
+      const win = windows.getNext();
+      try {
+        ww._loadCallback.call(null, win);
+      } catch (ex) {
+        ww._onError('WindowWatcher code loading callback failed: ', ex);
+      }
+    }
+
+    Services.ww.registerNotification(ww._onWindowOpened);
+  },
+
+  stop: function() {
+    if (!ww._isActive) {
+      ww._onError('called stop, but WindowWatcher was already stopped');
+      return;
+    }
+
+    const windows = Services.wm.getEnumerator('navigator:browser');
+    while (windows.hasMoreElements()) {
+      const win = windows.getNext();
+      try {
+        ww._unloadCallback(win);
+      } catch (ex) {
+        ww._onError('WindowWatcher code unloading callback failed: ', ex);
+      }
+    }
+
+    Services.ww.unregisterNotification(ww._onWindowOpened);
+
+    ww._loadCallback = null;
+    ww._unloadCallback = null;
+    ww._errback = null;
+    ww._isActive = false;
+  },
+
+  _onWindowOpened: function(win, topic) {
+    if (topic == 'domwindowopened') {
+      win.addEventListener('load', ww._onWindowLoaded, false);
+    }
+  },
+
+  _onWindowLoaded: function(e) {
+    // TODO: cleaner way to get window pointer?
+    const win = e.target.ownerGlobal;
+    win.removeEventListener('load', ww._onWindowLoaded, false);
+
+    // TODO: explain why we're checking this
+    if (win.location.href == 'chrome://browser/content/browser.xul') {
+      ww._loadCallback.call(null, win);
+    }
+  },
+
+  _onError: function(msg) {
+    ww._errback.call(null, msg);
+  }
+};
+
+const WindowWatcher = ww;


### PR DESCRIPTION
@chuckharmston R? This might make more sense together with the XBL code for issue 3, since the window iteration currently results in nothing happening (though you could set a console.log call inside the `loadIntoWindow` function to convince yourself it's actually getting called). I'm happy to add the XBL code to this PR tomorrow morning, but ran out of time for tonight.

Couple of TODOs in the window watcher code that I'd like to fix before landing, or could just fix in a follow-up PR.

Comments/questions welcome :-)

Adding "fixes #4" to try to help waffle, which seems to be confused about which issue this addresses.
