### PR TITLE
Insert hbox by overriding XBL bindings of existing popup

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -6,7 +6,7 @@ const {utils: Cu} = Components;
 
 Cu.import('resource://gre/modules/XPCOMUtils.jsm');
 XPCOMUtils.defineLazyModuleGetter(this, 'UniversalSearch',
-  'chrome://usearch-lib/content/universal-search.js');
+  'chrome://universalsearch-lib/content/universal-search.js');
 
 function startup(data, reason) {
   UniversalSearch.load();  
@@ -19,7 +19,7 @@ function shutdown(data, reason) {
   }
 
   UniversalSearch.unload();
-  Cu.unload('chrome://usearch-lib/universal-search.js');
+  Cu.unload('chrome://universalsearch-lib/universal-search.js');
 }
 
 function install(data, reason) {}

--- a/chrome.manifest
+++ b/chrome.manifest
@@ -1,1 +1,3 @@
-content usearch-lib lib/
+content universalsearch chrome/content/
+content universalsearch-lib lib/
+content universalsearch-skin chrome/skin/

--- a/chrome/content/binding.xml
+++ b/chrome/content/binding.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<bindings id="universal-search"
+          xmlns="http://www.mozilla.org/xbl"
+          xmlns:html="http://www.w3.org/1999/xhtml"
+          xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+          xmlns:xbl="http://www.mozilla.org/xbl">
+  <binding id="recommendation-popup" extends="chrome://browser/content/urlbarBindings.xml#urlbar-rich-result-popup">
+    <content ignorekeys="true" level="top" consumeoutsideclicks="never" aria-owns="richlistbox">
+      <xul:hbox id="universal-search-recommendation" />
+      <xul:richlistbox anonid="richlistbox" class="autocomplete-richlistbox" flex="1"/>
+      <xul:hbox anonid="footer">
+        <children/>
+      </xul:hbox>
+    </content>
+  </binding>
+</bindings>

--- a/chrome/skin/style.css
+++ b/chrome/skin/style.css
@@ -1,0 +1,10 @@
+/* Use extreme selector specificity to override the default bindings,
+ * defined in chrome://browser/content/browser.css, which use the single
+ * id selector #PopupAutoCompleteRichResult.
+ */
+popupset#mainPopupSet panel#PopupAutoCompleteRichResult {
+  /* This odd CSS property connects an XBL file with XUL DOM.
+   * See mdn.io/moz-binding for more.
+   */
+  -moz-binding: url("chrome://universalsearch/content/binding.xml#recommendation-popup");
+}

--- a/lib/universal-search.js
+++ b/lib/universal-search.js
@@ -10,7 +10,7 @@ XPCOMUtils.defineLazyModuleGetter(this, 'console',
 XPCOMUtils.defineLazyModuleGetter(this, 'CustomizableUI',
   'resource:///modules/CustomizableUI.jsm');
 XPCOMUtils.defineLazyModuleGetter(this, 'WindowWatcher',
-  'chrome://usearch-lib/content/window-watcher.js');
+  'chrome://universalsearch-lib/content/window-watcher.js');
 
 const EXPORTED_SYMBOLS = ['UniversalSearch'];
 
@@ -18,7 +18,7 @@ function Search() {}
 
 Search.prototype = {
   load: function() {
-    WindowWatcher.start(this.loadIntoWindow, this.unloadFromWindow, this.onError);
+    WindowWatcher.start(this.loadIntoWindow, this.unloadFromWindow, this.onError, this);
   },
 
   unload: function() {
@@ -27,17 +27,14 @@ Search.prototype = {
 
   loadIntoWindow: function(win) {
     console.log('loadIntoWindow start');
-    const document = win.document;
 
     // Sets the app global per window.
     win.universalSearch = win.universalSearch || {}
 
-    // If the search bar is visible, note the location and hide it.
-    const searchBarLocation = CustomizableUI.getPlacementOfWidget('search-container');
-    if (searchBarLocation) {
-      win.universalSearch.searchBarLocation = searchBarLocation;
-      CustomizableUI.removeWidgetFromArea('search-container');
-    }
+    this._hideSearchBar(win);
+    this._loadStyleSheets(win);
+    this._loadScripts(win);
+    this._startApp(win);
 
     console.log('loadIntoWindow finish');
   },
@@ -45,16 +42,73 @@ Search.prototype = {
   unloadFromWindow: function(win) {
     console.log('unloadFromWindow start');
 
-    // If the search bar was originally visible, restore it.
-    if (win.universalSearch.searchBarLocation) {
-      const loc = win.universalSearch.searchBarLocation;
-      CustomizableUI.addWidgetToArea('search-container', loc.area, loc.position);
-    }
+    this._stopApp(win);
+    this._unloadScripts(win);
+    this._unloadStyleSheets(win);
+    this._restoreSearchBar(win);
 
     // Delete any remaining references.
     delete win.universalSearch;
 
     console.log('unloadFromWindow finish');
+  },
+
+  _hideSearchBar: function(win) {
+    // If the search bar is visible, note the location and hide it.
+    const searchBarLocation = CustomizableUI.getPlacementOfWidget('search-container');
+    if (searchBarLocation) {
+      win.universalSearch.searchBarLocation = searchBarLocation;
+      CustomizableUI.removeWidgetFromArea('search-container');
+    }
+  },
+
+  _restoreSearchBar: function(win) {
+    // If the search bar was originally visible, restore it.
+    if (win.universalSearch.searchBarLocation) {
+      const loc = win.universalSearch.searchBarLocation;
+      CustomizableUI.addWidgetToArea('search-container', loc.area, loc.position);
+    }
+  },
+
+  _loadStyleSheets: function(win) {
+    const doc = win.document;
+    const docEl = doc.documentElement;
+
+    const stylesheet = doc.createElementNS('http://www.w3.org/1999/xhtml', 'h:link');
+    stylesheet.rel = 'stylesheet';
+    stylesheet.href = 'chrome://universalsearch-skin/content/style.css';
+    stylesheet.type = 'text/css';
+    stylesheet.id = 'universal-search-stylesheet';
+    stylesheet.style.display = 'none';
+
+    docEl.appendChild(stylesheet);
+  },
+
+  _unloadStyleSheets: function(win) {
+    const docEl = win.document.documentElement;
+    const stylesheet = docEl.getElementById('universal-search-stylesheet');
+
+    docEl.removeChild(stylesheet);
+  },
+
+  _loadScripts: function(win) {
+    // Note that we load the scripts into the app namespace, to ease cleanup.
+    // Each module's EXPORTED_SYMBOLS will be properties on win.US.
+    // Example: Cu.import('chrome://universalsearch-lib/content/something-in-lib.js', win.US);
+  },
+
+  _unloadScripts: function(win) {
+    // Unload scripts from the namespace. Not clear on whether this is necessary
+    // if we just delete win.US.
+    // Example: Cu.unload('chrome://universalsearch-lib/content/something-in-lib.js', win.US);
+  },
+
+  _startApp: function(win) {
+    // Initialize libraries and attach to the app global here
+  },
+
+  _stopApp: function(win) {
+    // Detach DOM listeners / elements, unset window pointers
   },
 
   onError: function(msg) {

--- a/lib/window-watcher.js
+++ b/lib/window-watcher.js
@@ -19,7 +19,7 @@ const ww = {
 
   _errback: null,
 
-  start: function(loadCallback, unloadCallback, errback) {
+  start: function(loadCallback, unloadCallback, errback, thisArg) {
     if (ww._isActive) {
       ww._onError('called start, but WindowWatcher was already running');
       return;
@@ -29,12 +29,13 @@ const ww = {
     ww._loadCallback = loadCallback;
     ww._unloadCallback = unloadCallback;
     ww._errback = errback;
+    ww._thisArg = thisArg;
 
     const windows = Services.wm.getEnumerator('navigator:browser');
     while (windows.hasMoreElements()) {
       const win = windows.getNext();
       try {
-        ww._loadCallback.call(null, win);
+        ww._loadCallback.call(ww._thisArg, win);
       } catch (ex) {
         ww._onError('WindowWatcher code loading callback failed: ', ex);
       }
@@ -80,12 +81,12 @@ const ww = {
 
     // TODO: explain why we're checking this
     if (win.location.href == 'chrome://browser/content/browser.xul') {
-      ww._loadCallback.call(null, win);
+      ww._loadCallback.call(ww._thisArg, win);
     }
   },
 
   _onError: function(msg) {
-    ww._errback.call(null, msg);
+    ww._errback.call(ww._thisArg, msg);
   }
 };
 


### PR DESCRIPTION
@chuckharmston R?

This patch uses selector specificity to insert our hbox into the existing popup. You can tell it's attached by inspecting the popup in the browser toolbox: it's under the `popupset` with id `mainPopupSet`, and our popup is the `panel` with id `PopupAutoCompleteRichResult`. There should be an hbox inside the popup with the anonid 'recommendation'. Here's a screenshot of how it looks in release FF:

<img width="663" alt="screen shot 2016-02-17 at 9 11 55 am" src="https://cloud.githubusercontent.com/assets/96396/13117865/85d3994a-d556-11e5-9406-2930d67d47b5.png">

I'm having some problems with Nightly. It seems like the XBL change is causing Nightly to fail to apply our styles, and then crash. Not sure if this is our changes or something busted in Nightly. I've opened #30 to investigate.

---

Original commit message:

Rather than inserting a new popup, we can use CSS specificity to
override the existing popup's XBL bindings, inserting our hbox above the
list of results.

Holding off on adding UI classes in this commit, so we still aren't
injecting any scripts into each window.

Closes #3.
