### PR TITLE
Adds preference to set recommendation server (closes #17).

### DIFF
--- a/chrome/content/preferences.xul
+++ b/chrome/content/preferences.xul
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE mydialog SYSTEM "chrome://myaddon/locale/mydialog.dtd">
+
+<vbox xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
+  <setting pref="extensions.universalsearch.server" type="menulist" title="Recommendation Server">
+    <menulist>
+      <menupopup>
+        <menuitem value="http://universal-search.dev" label="http://universal-search.dev"/>
+        <menuitem value="https://search.testpilot.firefox.com" label="https://search.testpilot.firefox.com"/>
+      </menupopup>
+    </menulist>
+  </setting>
+</vbox>

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -1,0 +1,1 @@
+pref('extensions.universalsearch.server', 'https://search.testpilot.firefox.com');

--- a/install.rdf
+++ b/install.rdf
@@ -10,6 +10,8 @@
     <em:description>Universal Search desktop FF experiments in addon format</em:description>
     <em:creator/>
     <em:homepageURL>https://github.com/mozilla/universal-search</em:homepageURL>
+    <em:optionsURL>chrome://universalsearch/content/preferences.xul</em:optionsURL>
+    <em:optionsType>2</em:optionsType>
     <!-- TODO: figure out the release URL (#24) -->
     <em:updateLink>https://example.com/dummy.xpi</em:updateLink>
     <em:targetApplication>

--- a/lib/recommendation-server.js
+++ b/lib/recommendation-server.js
@@ -16,17 +16,17 @@ function RecommendationServer(opts) {
     // events is an instance of lib/events
     events: events,
     xhr: Cc['@mozilla.org/xmlextras/xmlhttprequest;1'],
-    server: 'http://universal-search.dev',
+    prefs: prefs,
     timeout: 1000
   });
   recommendation.init();
   */
   this.events = opts.events;
-  this.server = opts.server;
   this.timeout = opts.timeout;
   // note: xhr service, not xhr instance
   this.xhr = opts.xhr;
   this.console = opts.console;
+  this.prefs = opts.prefs;
 
   this.search = this.search.bind(this);
 }
@@ -47,7 +47,8 @@ RecommendationServer.prototype = {
     this.events.unsubscribe('printable-key', this.search);
   },
   _url: function(query) {
-    return `${this.server}/?q=${encodeURIComponent(query)}`;
+    const server = this.prefs.getCharPref('server');
+    return `${server}/?q=${encodeURIComponent(query)}`;
   },
   warm: function() {
     /*

--- a/lib/universal-search.js
+++ b/lib/universal-search.js
@@ -9,6 +9,8 @@ XPCOMUtils.defineLazyModuleGetter(this, 'console',
   'resource://gre/modules/Console.jsm');
 XPCOMUtils.defineLazyModuleGetter(this, 'CustomizableUI',
   'resource:///modules/CustomizableUI.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'Services',
+  'resource://gre/modules/Services.jsm');
 XPCOMUtils.defineLazyModuleGetter(this, 'WindowWatcher',
   'chrome://universalsearch-lib/content/window-watcher.js');
 
@@ -31,6 +33,7 @@ Search.prototype = {
     // Sets the app global per window.
     win.universalSearch = win.universalSearch || {}
 
+    win.universalSearch.prefs = this._initializePrefs(win);
     this._hideSearchBar(win);
     this._loadStyleSheets(win);
     this._loadScripts(win);
@@ -51,6 +54,10 @@ Search.prototype = {
     delete win.universalSearch;
 
     console.log('unloadFromWindow finish');
+  },
+
+  _initializePrefs: function(win) {
+    return Services.prefs.getBranch('extensions.universalsearch.');
   },
 
   _hideSearchBar: function(win) {
@@ -128,11 +135,11 @@ Search.prototype = {
 
     app.recommendationServer = new app.RecommendationServer({
       events: app.events,
-      server: 'http://universal-search.dev/',
       xhr: Cc['@mozilla.org/xmlextras/xmlhttprequest;1'],
       timeout: 1000,
       // app.console is provided by loading Console.jsm
-      console: app.console
+      console: app.console,
+      prefs: app.prefs
     });
     app.recommendationServer.init();
 


### PR DESCRIPTION
r? @6a68 

<img width="970" alt="screen shot 2016-02-29 at 3 12 17 pm" src="https://cloud.githubusercontent.com/assets/23885/13410845/2178ac92-def7-11e5-889e-f8f3e7637cbe.png">

It's primitive, but I'm not sure there are better options, since we're modifying XBL and are thus unable to use the SDK.

Shortcut to get the value of the pref: `window.universalSearch.prefs.getCharPref('server')`
