### PR TITLE
Override the default urlbar key handler with a no-op handler

### DIFF
--- a/chrome/content/binding.xml
+++ b/chrome/content/binding.xml
@@ -13,4 +13,14 @@
       </xul:hbox>
     </content>
   </binding>
+
+  <binding id="recommendation-urlbar" extends="chrome://browser/content/urlbarBindings.xml#urlbar">
+    <handlers>
+      <handler event="keypress"><![CDATA[
+        // for now, just call the handler method defined on the parent binding.
+        // we'll add our own key handling logic in #43, #44.
+        return this.handleKeyPress(event);
+      ]]></handler>
+    </handlers>
+  </binding>
 </bindings>

--- a/chrome/skin/style.css
+++ b/chrome/skin/style.css
@@ -8,3 +8,11 @@ popupset#mainPopupSet panel#PopupAutoCompleteRichResult {
    */
   -moz-binding: url("chrome://universalsearch/content/binding.xml#recommendation-popup");
 }
+
+/* Same specificity trick here, to override the default bindings for the
+ * urlbar, also defined in chrome://browser/content/browser.css, which use
+ * the single id selector #urlbar.
+ */
+textbox#urlbar {
+  -moz-binding: url("chrome://universalsearch/content/binding.xml#recommendation-urlbar");
+}


### PR DESCRIPTION
@chuckharmston R?

It turns out that we need to extend the urlbar binding, not the popup binding, to capture keys. Once I realized I was listening to the wrong element, it was pretty easy :-P

You can verify that this is working by replacing the `return this.handleKeyPress` line with something like `alert('keypress!')`.

Waffle isn't making the connection, but this fixes #42.
