### PR TITLE
Detect printable keys in urlbar and fire event

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,21 @@ By participating in this project, you agree to abide by our [code of conduct](./
 - event naming convention: hyphenated lower case.
 	- we don't need to namespace it to individual items because it's such a small list of events. just keep it simple.
 
+## Pubsub events
+
+Events that flow through the global event broker (`app.events`, invoked as
+`this.events` by individual modules):
+
+#### `urlbar-change`
+
+When the user types a printable key in the urlbar, the complete string in
+the urlbar is fired as the body of this event.
+
+```
+{
+  query: 'the mar'
+}
+```
+
+- query: unicode string contents of the urlbar
+

--- a/chrome/content/binding.xml
+++ b/chrome/content/binding.xml
@@ -17,9 +17,9 @@
   <binding id="recommendation-urlbar" extends="chrome://browser/content/urlbarBindings.xml#urlbar">
     <handlers>
       <handler event="keypress"><![CDATA[
-        // for now, just call the handler method defined on the parent binding.
-        // we'll add our own key handling logic in #43, #44.
-        return this.handleKeyPress(event);
+        // If the urlbar handles the event, it returns true. Else, it returns
+        // false, and the existing XBL key handlers handle the key event.
+        return window.universalSearch.urlbar.onKeyPress(event) || this.handleKeyPress(event);
       ]]></handler>
     </handlers>
   </binding>

--- a/lib/recommendation-server.js
+++ b/lib/recommendation-server.js
@@ -70,7 +70,7 @@ RecommendationServer.prototype = {
       this.events.publish('recommendation', data);
     }, reason => {
       // TODO: send this information to metrics instead of logging
-      console.error(reason);
+      this.console.error(reason);
     });
   },
   _search: function(query) {

--- a/lib/recommendation-server.js
+++ b/lib/recommendation-server.js
@@ -38,13 +38,13 @@ RecommendationServer.prototype = {
     this.request.isInFlight = false;
     this.warm();
 
-    this.events.subscribe('printable-key', this.search);
+    this.events.subscribe('urlbar-change', this.search);
   },
   destroy: function() {
     this.request.abort();
     delete this.request;
 
-    this.events.unsubscribe('printable-key', this.search);
+    this.events.unsubscribe('urlbar-change', this.search);
   },
   _url: function(query) {
     const server = this.prefs.getCharPref('server');
@@ -65,8 +65,8 @@ RecommendationServer.prototype = {
       req.send();
     }
   },
-  search: function(query) {
-    this._search(query).then(data => {
+  search: function(payload) {
+    this._search(payload.query).then(data => {
       this.events.publish('recommendation', data);
     }, reason => {
       // TODO: send this information to metrics instead of logging

--- a/lib/ui/recommendation.js
+++ b/lib/ui/recommendation.js
@@ -25,14 +25,14 @@ Recommendation.prototype = {
 
     this.events.subscribe('recommendation', this.show);
     this.events.subscribe('enter-key', this.navigate);
-    this.events.subscribe('printable-key', this.hide);
+    this.events.subscribe('urlbar-change', this.hide);
     this.events.subscribe('before-popup-hide', this.hide);
   },
   destroy: function() {
     this.el.removeEventListener('click', this.navigate);
     this.events.unsubscribe('recommendation', this.show);
     this.events.unsubscribe('enter-key', this.navigate);
-    this.events.unsubscribe('printable-key', this.hide);
+    this.events.unsubscribe('urlbar-change', this.hide);
     this.events.unsubscribe('before-popup-hide', this.hide);
 
     delete this.el;

--- a/lib/ui/urlbar.js
+++ b/lib/ui/urlbar.js
@@ -7,25 +7,62 @@ const EXPORTED_SYMBOLS = ['Urlbar'];
 function Urlbar(opts) {
   this.win = opts.win;
   this.events = opts.events;
-
-  this.onKeyDown = this.onKeyDown.bind(this);
+  this.privateBrowsingUtils = opts.privateBrowsingUtils;
 }
 
 Urlbar.prototype = {
   init: function() {
     this.el = this.win.document.getElementById('urlbar');
-
-    this.el.addEventListener('keydown', this.onKeyDown);
   },
   destroy: function() {
     delete this.el;
     delete this.win;
   },
-  onKeyDown: function(evt) {
-    // check the key event:
-    // if it's a printable key, fire 'printable-key'
-    // if it's a navigational key, fire 'navigational-key'
-    // if we don't know what to do, return true or false
+  // Return `true` to prevent the existing Gecko key handler code from running.
+  onKeyPress: function(evt) {
+    // If the user's in private browsing mode, do nothing & hand the event
+    // back to the XBL handler.
+    if (this.privateBrowsingUtils.isWindowPrivate(this.win)) {
+      return false;
+    }
+
+    // We want to send printable keys to the recommendation server, but
+    // we also want the existing popup code to search history and fetch
+    // suggestions with that keystroke.
+    if (this.isPrintableKey(evt)) {
+      this.handlePrintableKey(evt);
+    }
+    // In #43 we might want to intercept navigational keys and prevent the
+    // existing code from handling them, depending on whether the
+    // recommendation is shown or not.
+  },
+  isPrintableKey: function(evt) {
+    // Criteria applied to decide if a key is printable:
+    //
+    // 1. Based on mdn.io/KeyboardEvent/key#Key_values, any printable key
+    //    will have an event.key value of length 1, that is, just the char
+    //    itself. Other keys will have longer string values, like 'Escape'.
+    //
+    // 2. If modifiers other than Shift are pressed, the user might be typing
+    //    a shortcut key combination. So, if those are pressed, do nothing.
+    return evt.key.length === 1 && !evt.ctrlKey && !evt.altKey && !evt.metaKey;
+  },
+  handlePrintableKey: function(evt) {
+    // We receive the key event before the corresponding character has been
+    // inserted into the urlbar. Rather than deal with checking the position of
+    // the caret, checking to see if there is a text selection in the urlbar
+    // that would be replaced by the string, and so on, we just set a timeout,
+    // give the browser a turn to update the string, and send that along.
+    //
+    // Note also that the urlbar autocompletes strings to domains in history.
+    // We don't want to send the autocompleted string (gURLBar.value), we want
+    // to send the string typed by the user (gBrowser.userTypedValue).
+    this.win.setTimeout(() => {
+      const data = {
+        query: this.win.gBrowser.userTypedValue
+      };
+      this.events.publish('urlbar-change', data);
+    });
   },
   navigate: function(url) {
     // set some urlbar state + navigate

--- a/lib/universal-search.js
+++ b/lib/universal-search.js
@@ -9,6 +9,8 @@ XPCOMUtils.defineLazyModuleGetter(this, 'console',
   'resource://gre/modules/Console.jsm');
 XPCOMUtils.defineLazyModuleGetter(this, 'CustomizableUI',
   'resource:///modules/CustomizableUI.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'PrivateBrowsingUtils',
+  'resource://gre/modules/PrivateBrowsingUtils.jsm');
 XPCOMUtils.defineLazyModuleGetter(this, 'Services',
   'resource://gre/modules/Services.jsm');
 XPCOMUtils.defineLazyModuleGetter(this, 'WindowWatcher',
@@ -145,7 +147,8 @@ Search.prototype = {
 
     app.urlbar = new app.Urlbar({
       win: win,
-      events: app.events
+      events: app.events,
+      privateBrowsingUtils: PrivateBrowsingUtils
     });
     app.urlbar.init();
 


### PR DESCRIPTION
@chuckharmston R?

This PR should be pretty straightforward, aside from using the Gecko-specific `KeyboardEvent.key` to decide if a key is printable or not.

You can test that this is working by pasting this into the Browser Toolbox console:

``` js
window.universalSearch.events.subscribe('printable-key', (e) => { console.log(JSON.stringify(e)) })
```

Then, as you type in the urlbar, you'll see the event fired if you typed a printable character.

I'm not sure if the event name should be `search-query` or `urlbar-updated`, or something else? One thing's for sure, the contents of the signal don't include a single printable key, so the term `printable-key` shouldn't be used. Suggestions welcome. APIs are hard :-P
