### PR TITLE
Intercept navigational keys if the recommendation is visible

### DIFF
--- a/chrome/content/binding.xml
+++ b/chrome/content/binding.xml
@@ -16,7 +16,7 @@
 
   <binding id="recommendation-urlbar" extends="chrome://browser/content/urlbarBindings.xml#urlbar">
     <handlers>
-      <handler event="keypress"><![CDATA[
+      <handler event="keypress" phase="capturing"><![CDATA[
         // If the urlbar handles the event, it returns true. Else, it returns
         // false, and the existing XBL key handlers handle the key event.
         return window.universalSearch.urlbar.onKeyPress(event) || this.handleKeyPress(event);

--- a/lib/ui/recommendation.js
+++ b/lib/ui/recommendation.js
@@ -73,7 +73,6 @@ RecommendationRow.prototype = {
 function Recommendation(opts) {
   this.win = opts.win;
   this.events = opts.events;
-  this.urlbar = opts.urlbar;
   this.el = null;
 
   this.navigate = this.navigate.bind(this);
@@ -84,10 +83,10 @@ function Recommendation(opts) {
 
 Recommendation.prototype = {
   init: function() {
-    // Note: there is a race between XBL modifying the XUL DOM to insert our
-    // this.el, and the scripts being loaded and initialized. Rather than try
-    // to fire a 'ready' event / set app state from the XBL <constructor>,
-    // which is sometimes unreliable, we instead poll the XUL DOM for the el.
+    // Note: the XUL DOM isn't updated to insert the
+    // 'universal-search-recommendation' element until the popup is opened
+    // once. So, poll for the element until it's ready, then attach listeners
+    // to it.
     this._pollForElement();
 
     this.events.subscribe('recommendation', this.show);
@@ -104,7 +103,6 @@ Recommendation.prototype = {
     this.events.unsubscribe('before-popup-hide', this.hide);
 
     delete this.el;
-    delete this.urlbar;
     delete this.win;
   },
 
@@ -114,7 +112,7 @@ Recommendation.prototype = {
       this.el = el;
       this.el.addEventListener('click', this.navigate);
     } else {
-      this.win.setTimeout(this._pollForElement, 20);
+      this.win.setTimeout(this._pollForElement, 75);
     }
   },
 
@@ -138,7 +136,7 @@ Recommendation.prototype = {
   navigate: function(evt) {
     // if it's a click, we'll have a MouseEvent; if it's a right-click, bail.
     // else, we'll just have the (possibly null) data from the 'enter-key' event.
-    // call this.urlbar.navigate to trigger navigation, passing in the URL.
-    // TODO: or should we fire an event and keep all the modules maximally disconnected?
+    // fire a 'recommendation-navigate' event to trigger navigation.
+    // the URL should already be set in the urlbar by the time the event is received.
   }
 };

--- a/lib/ui/urlbar.js
+++ b/lib/ui/urlbar.js
@@ -8,13 +8,20 @@ function Urlbar(opts) {
   this.win = opts.win;
   this.events = opts.events;
   this.privateBrowsingUtils = opts.privateBrowsingUtils;
+  this.recommendation = opts.recommendation;
+
+  this.navigate = this.navigate.bind(this);
 }
 
 Urlbar.prototype = {
   init: function() {
     this.el = this.win.document.getElementById('urlbar');
+
+    this.events.subscribe('recommendation-navigate', this.navigate);
   },
   destroy: function() {
+    this.events.unsubscribe('recommendation-navigate', this.navigate);
+
     delete this.el;
     delete this.win;
   },
@@ -31,10 +38,14 @@ Urlbar.prototype = {
     // suggestions with that keystroke.
     if (this.isPrintableKey(evt)) {
       this.handlePrintableKey(evt);
+    // Intercept navigational keys if the recommendation has been inserted into
+    // the XUL DOM (doesn't happen until the popup is opened once), and if the
+    // recommendation is currently visible.
+    } else if (this.isNavigationalKey(evt) && this.recommendation.el &&
+               !this.recommendation.el.collapsed) {
+      this.handleNavigationalKey(evt);
+      return true;
     }
-    // In #43 we might want to intercept navigational keys and prevent the
-    // existing code from handling them, depending on whether the
-    // recommendation is shown or not.
   },
   isPrintableKey: function(evt) {
     // Criteria applied to decide if a key is printable:
@@ -63,6 +74,17 @@ Urlbar.prototype = {
       };
       this.events.publish('urlbar-change', data);
     });
+  },
+  _navigationalKeys: ['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Tab'],
+  isNavigationalKey: function(evt) {
+    return this._navigationalKeys.indexOf(evt.key) > -1;
+  },
+  handleNavigationalKey: function(evt) {
+    const data = {
+      key: evt.key,
+      isShiftPressed: evt.shiftKey
+    };
+    this.events.publish('navigational-key', data);
   },
   navigate: function(url) {
     // set some urlbar state + navigate

--- a/lib/universal-search.js
+++ b/lib/universal-search.js
@@ -148,7 +148,8 @@ Search.prototype = {
     app.urlbar = new app.Urlbar({
       win: win,
       events: app.events,
-      privateBrowsingUtils: PrivateBrowsingUtils
+      privateBrowsingUtils: PrivateBrowsingUtils,
+      recommendation: app.recommendation
     });
     app.urlbar.init();
 
@@ -161,8 +162,7 @@ Search.prototype = {
 
     app.recommendation = new app.Recommendation({
       win: win,
-      events: app.events,
-      urlbar: app.urlbar
+      events: app.events
     });
     app.recommendation.init();
 


### PR DESCRIPTION
@chuckharmston R?

Interesting changes here:
- We have to set `phase="capturing"` on the XBL key handler to intercept the key before it is handled by the existing code. Gotta love those leftover decisions from the '90s browser wars...
- Had to adjust the urlbar/recommendation relationship to avoid circular constructor injection dependencies. If this gets any more annoying, I'm all for just passing an `app` reference around in the constructors. The current approach is: use events for one-way communication; use callbacks/promises for two-way communication. Thoughts/comments welcome.
- Updated the recommendation view docs to better explain why we're polling the XUL DOM.
- I'm not happy with the `navigational-key` event name, although it's reasonably descriptive. Suggestions very welcome.
