### PR TITLE
Pass highlight between recommendation and results list

### DIFF
--- a/chrome/content/binding.xml
+++ b/chrome/content/binding.xml
@@ -4,6 +4,13 @@
           xmlns:html="http://www.w3.org/1999/xhtml"
           xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
           xmlns:xbl="http://www.mozilla.org/xbl">
+
+  <![CDATA[
+    /*
+     * Override the default binding, inserting a recommendation element in
+     * the popup above the list of history/suggestion results.
+     */
+  ]]>
   <binding id="recommendation-popup" extends="chrome://browser/content/urlbarBindings.xml#urlbar-rich-result-popup">
     <content ignorekeys="true" level="top" consumeoutsideclicks="never" aria-owns="richlistbox">
       <xul:hbox id="universal-search-recommendation" collapsed="true"/>
@@ -12,12 +19,98 @@
         <children/>
       </xul:hbox>
     </content>
+    <implementation>
+      <![CDATA[
+        /*
+         * The selectedIndex setter sets the blue highlight on the currently-
+         * selected item in the results list. The existing implementation,
+         * defined in autocomplete.xml, automatically closes the popup if no
+         * results list items are selected (selectedIndex = -1).
+         *
+         * Override the setter, removing the auto-close behavior, so that the
+         * universal search recommendation element can steal the highlight.
+         */
+      ]]>
+      <field name="_selectedIndex">-1</field>
+      <property name="selectedIndex">
+        <getter>
+          return this._selectedIndex;
+        </getter>
+        <setter><![CDATA[
+          var resultsContainer = document.getAnonymousElementByAttribute(gURLBar.popup, 'anonid', 'richlistbox');
+
+          // NOTE: getElementsByClassName is needed to obtain a live NodeList.
+          // The results aren't inserted all at once: they are inserted a few
+          // at a time over many successive turns. In order to avoid setting
+          // the selectedIndex past the end of the results list, and also to
+          // avoid mistakenly concluding that the results list is empty, the
+          // NodeList needs to be live, not static.
+          var resultRows = resultsContainer.getElementsByClassName('autocomplete-richlistitem');
+
+          if (!resultRows || !resultRows.length) {
+            return;
+          }
+
+          if (val > resultRows.length - 1) {
+            val = resultRows.length - 1;
+          } else if (val < -1) {
+            val = -1;
+          }
+
+          // Unselect all the rows (in case of any weird multiple-focus bugs),
+          // then immediately select the appropriate row, to hopefully batch
+          // the selection changes into a single DOM update.
+          Array.prototype.forEach.call(resultRows, function(row, i) {
+            row.selected = false;
+          });
+
+          // Highlight the row, if it's found, else highlight nothing.
+          if (resultRows[val]) {
+            resultRows[val].selected = true;
+            // Scroll the row into view, if necessary.
+            resultsContainer.ensureIndexIsVisible(val);
+            this._selectedIndex = val;
+            return val;
+          } else {
+            this._selectedIndex = -1;
+            return -1;
+          }
+        ]]></setter>
+      </property>
+
+      <![CDATA[
+        /*
+         * The urlbar stops working if getNextIndex is not overridden here.
+         * This implementation doesn't handle certain edge cases, like
+         * scrolling off the top or bottom of the list, but whatever code
+         * calls this code doesn't seem to hit that bug.
+         */
+      ]]>
+      <method name="getNextIndex">
+        <parameter name="reverse"/>
+        <parameter name="amount"/>
+        <parameter name="index"/>
+        <parameter name="maxRow"/>
+        <body><![CDATA[
+          let realAmount = amount % maxRow;
+          this._selectedIndex = reverse ? this._selectedIndex - realAmount: this._selectedIndex + realAmount;
+          return this._selectedIndex;
+        ]]></body>
+      </method>
+    </implementation>
   </binding>
 
+  <![CDATA[
+    /*
+     * Override the urlbar so that the universal search code can conditionally
+     * intercept key events before they are sent to the existing urlbar key
+     * handler code, defined in urlbarBindings.xml.
+     */
+  ]]>
   <binding id="recommendation-urlbar" extends="chrome://browser/content/urlbarBindings.xml#urlbar">
     <handlers>
       <handler event="keypress" phase="capturing"><![CDATA[
-        // If the urlbar handles the event, it returns true. Else, it returns
+        // If our add-on handles the event, it returns true. Else, it returns
         // false, and the existing XBL key handlers handle the key event.
         return window.universalSearch.urlbar.onKeyPress(event) || this.handleKeyPress(event);
       ]]></handler>

--- a/chrome/skin/style.css
+++ b/chrome/skin/style.css
@@ -1,15 +1,18 @@
-/* Use extreme selector specificity to override the default bindings,
+/*
+ * Use extreme selector specificity to override the default bindings,
  * defined in chrome://browser/content/browser.css, which use the single
  * id selector #PopupAutoCompleteRichResult.
  */
 popupset#mainPopupSet panel#PopupAutoCompleteRichResult {
-  /* This odd CSS property connects an XBL file with XUL DOM.
+  /*
+   * This odd CSS property connects an XBL file with XUL DOM.
    * See mdn.io/moz-binding for more.
    */
   -moz-binding: url("chrome://universalsearch/content/binding.xml#recommendation-popup");
 }
 
-/* Same specificity trick here, to override the default bindings for the
+/*
+ * Same specificity trick here, to override the default bindings for the
  * urlbar, also defined in chrome://browser/content/browser.css, which use
  * the single id selector #urlbar.
  */
@@ -18,7 +21,7 @@ textbox#urlbar {
 }
 
 #universal-search-recommendation {
-  border-bottom: solid 1px #D6D6D6;
+  border-bottom: none;
   display: flex;
   padding: 8px 15px 8px 9px;
   width: 100%;
@@ -132,4 +135,15 @@ textbox#urlbar {
   flex-grow: 1;
   margin-left: 8px;
   text-align: right;
+}
+
+/* highlight color, applied when the recommendation is highlighted */
+
+#universal-search-recommendation.highlight {
+  background-color: Highlight;
+  background-image: linear-gradient(rgba(255,255,255,0.3), transparent);
+  color: HighlightText;
+}
+#universal-search-recommendation.highlight #universal-search-recommendation-url {
+  color: HighlightText;
 }

--- a/lib/events.js
+++ b/lib/events.js
@@ -4,7 +4,17 @@
 
 const EXPORTED_SYMBOLS = ['Events'];
 
-function Events() {}
+function Events() {
+  /*
+  The Events module provides a very simple JS pubsub implementation. Callers
+  need to bind callbacks before subscribing.
+
+  Interestingly, it doesn't seem like Gecko has a shared JS messaging service
+  other than the nsIObserverService, which is Firefox-global. We load a
+  separate instance of this object into each ChromeWindow, to provide
+  messaging between per-window components.
+  */
+}
 
 Events.prototype = {
   init: function() {
@@ -24,14 +34,14 @@ Events.prototype = {
       return;
     }
 
-    // remove any matching subscribers
+    // Remove any matching subscribers.
     this.topics[topic].forEach((callback, i) => {
       if (callback === cb) {
         this.topics[topic].splice(i, 1);
       }
     });
 
-    // if the topic's empty, remove it
+    // If the topic has no subscribers left, remove it.
     if (!this.topics[topic].length) {
       delete this.topics[topic];
     }

--- a/lib/ui/highlight-manager.js
+++ b/lib/ui/highlight-manager.js
@@ -5,40 +5,183 @@
 const EXPORTED_SYMBOLS = ['HighlightManager'];
 
 function HighlightManager(opts) {
+  /*
+   The Highlight Manager abstracts out the task of adjusting the blue highlight
+   in the autocomplete popup in response to key and mouse events, as well as
+   in response to the recommendation being shown.
+   */
   this.win = opts.win;
   this.events = opts.events;
   // this is a recommendation view, because the highlight
   // class manages passing focus between it and the list of results
-  this.recommendationView = opts.recommendationView;
+  this.recommendation = opts.recommendation;
+  this.stealHighlightTimeout = null;
 
   this.adjustHighlight = this.adjustHighlight.bind(this);
+  this.stealHighlight = this.stealHighlight.bind(this);
+  this.mutationHandler = this.mutationHandler.bind(this);
+  this.initMutationObserver = this.initMutationObserver.bind(this);
 }
 
 HighlightManager.prototype = {
   init: function() {
     this.events.subscribe('navigational-key', this.adjustHighlight);
-    this.events.subscribe('recommendation-shown', this.adjustHighlight);
+    // It seems that the recommendation is rarely in the XUL DOM when this init
+    // function runs, so listen for the recommendation to be found in the DOM,
+    // then try a second time to attach the MutationObserver to the element.
+    this.events.subscribe('recommendation-created', this.initMutationObserver);
+    this.events.subscribe('recommendation-shown', this.stealHighlight);
 
     this.popup = this.win.document.getElementById('PopupAutoCompleteRichResult');
 
-    // TODO: maybe we can hook into the XBL mousemove handler and steal focus
-    // that way instead of manually setting a mousemove listener
-    this.popup.addEventListener('mousemove', this.adjustHighlight);
+    this.initMutationObserver();
   },
   destroy: function() {
-    this.popup.removeEventListener('mousemove', this.adjustHighlight);
-    this.events.unsubscribe('recommendation-shown', this.adjustHighlight);
+    this.resultsObserver.disconnect();
+    this.events.unsubscribe('recommendation-shown', this.stealHighlight);
     this.events.unsubscribe('navigational-key', this.adjustHighlight);
     delete this.popup;
     delete this.recommendationView;
     delete this.win;
   },
+  initMutationObserver: function() {
+    // The existing code doesn't insert all the results at once; instead, rows
+    // are inserted after repeated timeouts, to keep the urlbar responsive (see
+    // _appendResultTimeout in autocomplete.xml). Each time some rows are
+    // inserted, the existing code reapplies the highlight to an item in the
+    // results list. So, as that happens, we want to continually steal the
+    // highlight back.
+    // The simplest way to do this, it turns out, is with a MutationObserver.
+    // Listen for changes to the `url` attribute on the rows inside the results
+    // richlistbox. This ensures changes are detected, even when rows are
+    // reused, rather than created (see _adjustAcItem in autocomplete.xml).
+    this.resultsObserver = new this.win.MutationObserver(this.mutationHandler);
+    const results = this.win.document.getAnonymousElementByAttribute(this.popup, 'anonid', 'richlistbox');
+    const resultsObserverConfig = {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['url']
+    };
+    this.resultsObserver.observe(results, resultsObserverConfig);
+  },
+  mutationHandler: function() {
+    // If the recommendation exists and is visible, steal the highlight.
+    if (this.recommendation.el && !this.recommendation.el.collapsed) {
+      this.stealHighlight();
+    }
+  },
+  stealHighlight: function() {
+    // Retake control of the highlight under two circumstances:
+    // - when the recommendation has just been shown, if the user isn't keying
+    //   through the list already, then move the highlight from the top results
+    //   list item to the recommendation;
+    // - when a few results have been inserted into the DOM, causing the Gecko
+    //   code to move the highlight, steal it back.
+    //
+    // The existing XBL code batches insertions in timeouts. By default,
+    // 30 rows are inserted in groups of 6, invoking setTimeout 5 times.
+    // Because the event loop already has up to 5 timers waiting, we can't
+    // rely on setTimeout to steal the highlight: our request will be queued
+    // behind all those other timers, causing a noticeably long flicker of the
+    // blue highlight on the top result row.
+    //
+    // Our workaround relies on using requestAnimationFrame to cut in line,
+    // interleaving our highlight stealing between the setTimeouts.
+    // Specifically, each time stealHighlight is called (in response to a DOM
+    // mutation fired when rows are inserted into the list), we ask the browser
+    // to steal the highlight three times: immediately, just before the next
+    // frame is painted (the outer rAF), and just before the frame after that
+    // (the inner rAF).
+    //
+    // This is a weird hack, but it works fairly well; because setTimeout makes
+    // no guarantees about precisely when a callback will be executed, and
+    // because the row insertion timeouts are called closely together, ours is
+    // a pretty good, though nondeterministic, solution.
+    if (!this.recommendation.el || this.recommendation.el.collapsed) {
+      return;
+    }
+    this.recommendation.isHighlighted = true;
+    this.popup.selectedIndex = -1;
+    this.win.requestAnimationFrame(() => {
+      this.recommendation.isHighlighted = true;
+      this.popup.selectedIndex = -1;
+      this.win.requestAnimationFrame(() => {
+        this.recommendation.isHighlighted = true;
+        this.popup.selectedIndex = -1;
+      });
+    });
+  },
+  clearHighlight: function() {
+    const resultsContainer = this.win.document.getAnonymousElementByAttribute(this.popup, 'anonid', 'richlistbox');
+    const resultRows = resultsContainer.getElementsByClassName('autocomplete-richlistitem');
+    Array.prototype.forEach.call(resultRows, row => { row.selected = false; });
+  },
   adjustHighlight: function(evt) {
-    // if the recommendation isn't shown, do nothing: let the popup manage focus
-    // otherwise,
-    // check if the recommendation is shown + highlighted
-    // check the selectedIndex of the popup
-    // if it's a down key, move the focus downward, wrapping around if needed
-    // if it's an up key, move the focus upward, wrapping around if needed
+    // Due to constraints in combining XBL and JS, we have to totally take over
+    // highlight management for the list of results as well as the recommendation.
+    //
+    // adjustHighlight resets the DOM highlight state to what we want.
+    // It runs in three phases: first, checking the old state; second, clearing
+    // the highlight off of all results (putting the DOM into a dirty state);
+    // third, modifying the DOM. The idea is to avoid triggering repaints by
+    // batching reads and writes, rather than interleaving them.
+
+    // Batch all DOM access here at the start of the function.
+    const resultsContainer = this.win.document.getAnonymousElementByAttribute(this.popup, 'anonid', 'richlistbox');
+    const resultRows = resultsContainer.getElementsByClassName('autocomplete-richlistitem');
+    // resultRows is a live collection, and the XBL code inserts elements over
+    // several turns, so we'll use listLength for calculating the past state
+    // of the world, but when we want to assign focus to the last item in the
+    // list, we'll use the live collection.
+    const listLength = resultRows.length;
+    const selectedIndex = this.popup.selectedIndex;
+    const recommendationVisible = this.recommendation.el && !this.recommendation.el.collapsed;
+    const recommendationHighlighted = this.recommendation.el && this.recommendation.isHighlighted;
+
+    // Clear all highlights. The DOM is now dirty and not trustworthy.
+    this.clearHighlight();
+
+    // If the recommendation was highlighted,
+    // a 'forward' key moves the highlight to the first result in the list,
+    // a 'backward' key moves the highlight to the bottom of the list.
+    if (recommendationHighlighted) {
+      this.recommendation.isHighlighted = false;
+      this.popup.selectedIndex = (evt.forward) ? 0 : resultRows.length - 1;
+
+    // If the first result in the list was highlighted,
+    // a 'forward' key moves the highlight to the 2nd result in the list,
+    // a 'backward' key moves the highlight to the recommendation, if it's
+    // visible, else to the last result in the list.
+    } else if (selectedIndex === 0) {
+      if (evt.forward) {
+        this.popup.selectedIndex = 1;
+      } else if (recommendationVisible) {
+        this.popup.selectedIndex = -1;
+        this.recommendation.isHighlighted = true;
+      } else {
+        this.popup.selectedIndex = resultRows.length - 1;
+      }
+
+    // If the last result in the list was highlighted,
+    // a 'forward' key moves the highlight to the recommendation, if it's
+    // visible, else to the first result;
+    // a 'backward' key moves the highlight to the result 2nd from the end
+    // of the list.
+    } else if (selectedIndex === listLength - 1) {
+      if (evt.forward && recommendationVisible) {
+        this.popup.selectedIndex = -1;
+        this.recommendation.isHighlighted = true;
+      } else if (evt.forward && !recommendationVisible) {
+        this.popup.selectedIndex = 0;
+      } else {
+        this.popup.selectedIndex = selectedIndex - 1;
+      }
+
+    // If the highlighted result was in the middle of the list,
+    // then move the highlight to one of its neighbors.
+    } else {
+      this.popup.selectedIndex = evt.forward ? selectedIndex + 1 : selectedIndex - 1;
+    }
   }
 };

--- a/lib/ui/popup.js
+++ b/lib/ui/popup.js
@@ -5,6 +5,10 @@
 const EXPORTED_SYMBOLS = ['Popup'];
 
 function Popup(opts) {
+  /*
+  The Popup module abstracts the XUL popup. Currently only used to listen for
+  events emitted by the popup.
+  */
   this.win = opts.win;
   this.events = opts.events;
 

--- a/lib/ui/recommendation-row.js
+++ b/lib/ui/recommendation-row.js
@@ -10,6 +10,10 @@ const IMAGE_DIMENSION = 32;
 
 
 function RecommendationRow(data, opts) {
+  /*
+  The RecommendationRow is a helper class that contains verbose DOM creation
+  methods used to create the element managed by the Recommendation module.
+  */
   this.win = opts.win;
   this.doc = opts.win.document;
   this.eTLD = opts.eTLD;

--- a/lib/ui/recommendation.js
+++ b/lib/ui/recommendation.js
@@ -6,13 +6,32 @@ const EXPORTED_SYMBOLS = ['Recommendation'];
 const RECOMMENDATION_ID = 'universal-search-recommendation';
 
 function Recommendation(opts) {
+  /*
+  The Recommendation module manages the XUL UI for the server recommendation.
+  */
   this.win = opts.win;
   this.events = opts.events;
   this.eTLD = opts.eTLD;
   this.io = opts.io;
   this.el = null;
   this.timeout = null;
-  this.RecommendationRow = this.win.universalSearch.RecommendationRow;
+  this.RecommendationRow = opts.RecommendationRow;
+
+  Object.defineProperty(this, 'isHighlighted', {
+    get: () => {
+      return this.el && this.el.classList.contains('highlight');
+    },
+    set: (shouldHighlight) => {
+      if (!this.el) {
+        return;
+      }
+      if (shouldHighlight) {
+        this.el.classList.add('highlight');
+      } else {
+        this.el.classList.remove('highlight');
+      }
+    }
+  });
 
   this.navigate = this.navigate.bind(this);
   this.show = this.show.bind(this);
@@ -50,6 +69,7 @@ Recommendation.prototype = {
     if (el) {
       this.el = el;
       this.el.addEventListener('click', this.navigate);
+      this.events.publish('recommendation-created');
     } else {
       this.win.setTimeout(this._pollForElement, 75);
     }
@@ -81,7 +101,7 @@ Recommendation.prototype = {
     if (this.el) {
       const container = this.win.document.getElementById(RECOMMENDATION_ID);
       this.timeout = this.win.setTimeout(function() {
-        // this.el.collapsed = true;
+        this.el.collapsed = true;
       }.bind(this), 50);
       this.data = null;
     }

--- a/lib/ui/urlbar.js
+++ b/lib/ui/urlbar.js
@@ -5,6 +5,11 @@
 const EXPORTED_SYMBOLS = ['Urlbar'];
 
 function Urlbar(opts) {
+  /*
+  The Urlbar abstracts the urlbar in the XUL DOM. It handles keystrokes in the
+  urlbar, passing them along to the other modules via pubsub events if the
+  key events should be handled by the add-on.
+  */
   this.win = opts.win;
   this.events = opts.events;
   this.privateBrowsingUtils = opts.privateBrowsingUtils;
@@ -38,11 +43,8 @@ Urlbar.prototype = {
     // suggestions with that keystroke.
     if (this.isPrintableKey(evt) || this.isDeleteKey(evt)) {
       this.handlePrintableKey(evt);
-    // Intercept navigational keys if the recommendation has been inserted into
-    // the XUL DOM (doesn't happen until the popup is opened once), and if the
-    // recommendation is currently visible.
-    } else if (this.isNavigationalKey(evt) && this.recommendation.el &&
-               !this.recommendation.el.collapsed) {
+    // If we get a navigational key, adjust the highlight.
+    } else if (this.isNavigationalKey(evt)) {
       this.handleNavigationalKey(evt);
       return true;
     }
@@ -85,9 +87,11 @@ Urlbar.prototype = {
     return this._navigationalKeys.indexOf(evt.key) > -1;
   },
   handleNavigationalKey: function(evt) {
+    // preventDefault on the event, otherwise it seems up and down move two
+    // steps at a time, some key handler way down in the XUL stack
+    evt.preventDefault();
     const data = {
-      key: evt.key,
-      isShiftPressed: evt.shiftKey
+      forward: evt.key === 'ArrowDown' || evt.key === 'PageDown' || (evt.key === 'Tab' && !evt.shiftKey)
     };
     this.events.publish('navigational-key', data);
   },

--- a/lib/universal-search.js
+++ b/lib/universal-search.js
@@ -18,7 +18,13 @@ XPCOMUtils.defineLazyModuleGetter(this, 'WindowWatcher',
 
 const EXPORTED_SYMBOLS = ['UniversalSearch'];
 
-function Search() {}
+function Search() {
+  /*
+  The main UniversalSearch module manages the add-on lifecycle, loading and
+  unloading code when the add-on is installed, enabled, disabled, or
+  uninstalled. It's invoked by the bootstrap.js file.
+  */
+}
 
 Search.prototype = {
   load: function() {
@@ -133,7 +139,8 @@ Search.prototype = {
   },
 
   _startApp: function(win) {
-    // Initialize libraries and attach to the app global here
+    // Initialize modules and assemble the object graph.
+
     const app = win.universalSearch;
 
     app.events = new app.Events();
@@ -148,6 +155,17 @@ Search.prototype = {
       prefs: app.prefs
     });
     app.recommendationServer.init();
+
+    // NOTE: order matters here, the urlbar and highlightManager both need
+    // to be handed the initialized recommendation
+    app.recommendation = new app.Recommendation({
+      eTLD: Services.eTLD,
+      events: app.events,
+      io: Services.io,
+      win: win,
+      RecommendationRow: app.RecommendationRow
+    });
+    app.recommendation.init();
 
     app.urlbar = new app.Urlbar({
       win: win,
@@ -164,14 +182,6 @@ Search.prototype = {
     });
     app.highlightManager.init();
 
-    app.recommendation = new app.Recommendation({
-      eTLD: Services.eTLD,
-      events: app.events,
-      io: Services.io,
-      win: win
-    });
-    app.recommendation.init();
-
     app.popup = new app.Popup({
       win: win,
       events: app.events
@@ -183,7 +193,7 @@ Search.prototype = {
     const app = win.universalSearch;
 
     app.popup.destroy();
-    app.recommendationView.destroy();
+    app.recommendation.destroy();
     app.highlightManager.destroy();
     app.urlbar.destroy();
     app.recommendationServer.destroy();

--- a/lib/window-watcher.js
+++ b/lib/window-watcher.js
@@ -10,6 +10,19 @@ XPCOMUtils.defineLazyModuleGetter(this, 'Services',
 
 const EXPORTED_SYMBOLS = ['WindowWatcher'];
 
+/*
+The WindowWatcher is a helper object that iterates over open browser windows
+and fires a callback, allowing code to be loaded into each window. It also
+listens for the creation of new windows, and fires a callback when the new
+window is loaded.
+
+Most of the contents are boilerplate copied from the MDN docs for the
+WindowManager and WindowWatcher XPCOM services.
+
+The WindowWatcher is used by the main UniversalSearch module to manage the
+add-on lifecycle.
+*/
+
 const ww = {
   _isActive: false,
 


### PR DESCRIPTION
Reopening previous PR, need to take a final look. @chuckharmston, if you want to verify this works for you, that would be great, but no worries if not.

Remainder of commit message follows:

---

Highlights:
- Always handle navigational keys, now that we are replacing the XBL
  focus logic.
- Use mutation observer to steal focus over and over as rows are
  inserted into the popup.
- Use 2 requestAnimationFrames to minimize the amount of blue highlight
  flickering on the zeroth result list item as results stream in.
- Take an initial swing at the highlight style.
- Improve documentation throughout.

Fixes #38.
