### PR TITLE
Manage mouse highlight (fixes #39)

### DIFF
--- a/chrome/content/binding.xml
+++ b/chrome/content/binding.xml
@@ -19,85 +19,6 @@
         <children/>
       </xul:hbox>
     </content>
-    <implementation>
-      <![CDATA[
-        /*
-         * The selectedIndex setter sets the blue highlight on the currently-
-         * selected item in the results list. The existing implementation,
-         * defined in autocomplete.xml, automatically closes the popup if no
-         * results list items are selected (selectedIndex = -1).
-         *
-         * Override the setter, removing the auto-close behavior, so that the
-         * universal search recommendation element can steal the highlight.
-         */
-      ]]>
-      <field name="_selectedIndex">-1</field>
-      <property name="selectedIndex">
-        <getter>
-          return this._selectedIndex;
-        </getter>
-        <setter><![CDATA[
-          var resultsContainer = document.getAnonymousElementByAttribute(gURLBar.popup, 'anonid', 'richlistbox');
-
-          // NOTE: getElementsByClassName is needed to obtain a live NodeList.
-          // The results aren't inserted all at once: they are inserted a few
-          // at a time over many successive turns. In order to avoid setting
-          // the selectedIndex past the end of the results list, and also to
-          // avoid mistakenly concluding that the results list is empty, the
-          // NodeList needs to be live, not static.
-          var resultRows = resultsContainer.getElementsByClassName('autocomplete-richlistitem');
-
-          if (!resultRows || !resultRows.length) {
-            return;
-          }
-
-          if (val > resultRows.length - 1) {
-            val = resultRows.length - 1;
-          } else if (val < -1) {
-            val = -1;
-          }
-
-          // Unselect all the rows (in case of any weird multiple-focus bugs),
-          // then immediately select the appropriate row, to hopefully batch
-          // the selection changes into a single DOM update.
-          Array.prototype.forEach.call(resultRows, function(row, i) {
-            row.selected = false;
-          });
-
-          // Highlight the row, if it's found, else highlight nothing.
-          if (resultRows[val]) {
-            resultRows[val].selected = true;
-            // Scroll the row into view, if necessary.
-            resultsContainer.ensureIndexIsVisible(val);
-            this._selectedIndex = val;
-            return val;
-          } else {
-            this._selectedIndex = -1;
-            return -1;
-          }
-        ]]></setter>
-      </property>
-
-      <![CDATA[
-        /*
-         * The urlbar stops working if getNextIndex is not overridden here.
-         * This implementation doesn't handle certain edge cases, like
-         * scrolling off the top or bottom of the list, but whatever code
-         * calls this code doesn't seem to hit that bug.
-         */
-      ]]>
-      <method name="getNextIndex">
-        <parameter name="reverse"/>
-        <parameter name="amount"/>
-        <parameter name="index"/>
-        <parameter name="maxRow"/>
-        <body><![CDATA[
-          let realAmount = amount % maxRow;
-          this._selectedIndex = reverse ? this._selectedIndex - realAmount: this._selectedIndex + realAmount;
-          return this._selectedIndex;
-        ]]></body>
-      </method>
-    </implementation>
   </binding>
 
   <![CDATA[
@@ -113,6 +34,20 @@
         // If our add-on handles the event, it returns true. Else, it returns
         // false, and the existing XBL key handlers handle the key event.
         return window.universalSearch.urlbar.onKeyPress(event) || this.handleKeyPress(event);
+      ]]></handler>
+    </handlers>
+  </binding>
+
+  <![CDATA[
+    /*
+     * Override the results list binding in order to intercept mouse events
+     * fired on it.
+     */
+  ]]>
+  <binding id="autocomplete-richlistbox" extends="chrome://global/content/bindings/autocomplete.xml#autocomplete-richlistbox">
+    <handlers>
+      <handler event="mouseover" phase="capturing"><![CDATA[
+        window.universalSearch.popup.onResultsMouseOver(event);
       ]]></handler>
     </handlers>
   </binding>

--- a/chrome/skin/style.css
+++ b/chrome/skin/style.css
@@ -20,6 +20,10 @@ textbox#urlbar {
   -moz-binding: url("chrome://universalsearch/content/binding.xml#recommendation-urlbar");
 }
 
+popupset#mainPopupSet panel#PopupAutoCompleteRichResult richlistbox {
+  -moz-binding: url("chrome://universalsearch/content/binding.xml#autocomplete-richlistbox");
+}
+
 #universal-search-recommendation {
   border-bottom: none;
   display: flex;

--- a/lib/ui/highlight-manager.js
+++ b/lib/ui/highlight-manager.js
@@ -12,6 +12,7 @@ function HighlightManager(opts) {
    */
   this.win = opts.win;
   this.events = opts.events;
+  this.popup = opts.popup;
   // this is a recommendation view, because the highlight
   // class manages passing focus between it and the list of results
   this.recommendation = opts.recommendation;
@@ -28,8 +29,6 @@ function HighlightManager(opts) {
 
 HighlightManager.prototype = {
   init: function() {
-    this.popup = this.win.document.getElementById('PopupAutoCompleteRichResult');
-
     this.events.subscribe('navigational-key', this.adjustHighlight);
     // It seems that the recommendation is rarely in the XUL DOM when this init
     // function runs, so listen for the recommendation to be found in the DOM,
@@ -124,7 +123,7 @@ HighlightManager.prototype = {
     // reused, rather than created (see the use of maxRows in _adjustAcItem,
     // inside autocomplete.xml).
     this.resultsObserver = new this.win.MutationObserver(this.mutationHandler);
-    const results = this.win.document.getAnonymousElementByAttribute(this.popup, 'anonid', 'richlistbox');
+    const results = this.win.document.getAnonymousElementByAttribute(this.popup.el, 'anonid', 'richlistbox');
     const resultsObserverConfig = {
       childList: true,
       subtree: true,
@@ -170,18 +169,18 @@ HighlightManager.prototype = {
       return;
     }
     this.recommendation.isHighlighted = true;
-    this.popup.selectedIndex = -1;
+    this.popup.el.selectedIndex = -1;
     this.win.requestAnimationFrame(() => {
       this.recommendation.isHighlighted = true;
-      this.popup.selectedIndex = -1;
+      this.popup.el.selectedIndex = -1;
       this.win.requestAnimationFrame(() => {
         this.recommendation.isHighlighted = true;
-        this.popup.selectedIndex = -1;
+        this.popup.el.selectedIndex = -1;
       });
     });
   },
   clearHighlight: function() {
-    this.popup.richlistbox.selectedIndex = -1;
+    this.popup.el.richlistbox.selectedIndex = -1;
     this.recommendation.isHighlighted = false;
   },
   clearRecommendationHighlight: function() {
@@ -199,14 +198,14 @@ HighlightManager.prototype = {
     // batching reads and writes, rather than interleaving them.
 
     // Batch all DOM access here at the start of the function.
-    const resultsContainer = this.win.document.getAnonymousElementByAttribute(this.popup, 'anonid', 'richlistbox');
+    const resultsContainer = this.win.document.getAnonymousElementByAttribute(this.popup.el, 'anonid', 'richlistbox');
     const resultRows = resultsContainer.getElementsByClassName('autocomplete-richlistitem');
     // resultRows is a live collection, and the XBL code inserts elements over
     // several turns, so we'll use listLength for calculating the past state
     // of the world, but when we want to assign focus to the last item in the
     // list, we'll use the live collection.
     const listLength = resultRows.length;
-    const selectedIndex = this.popup.selectedIndex;
+    const selectedIndex = this.popup.el.selectedIndex;
     const recommendationVisible = this.recommendation.el && !this.recommendation.el.collapsed;
     const recommendationHighlighted = this.recommendation.el && this.recommendation.isHighlighted;
 
@@ -218,7 +217,7 @@ HighlightManager.prototype = {
     // a 'backward' key moves the highlight to the bottom of the list.
     if (recommendationHighlighted) {
       this.recommendation.isHighlighted = false;
-      this.popup.selectedIndex = (evt.forward) ? 0 : resultRows.length - 1;
+      this.popup.el.selectedIndex = (evt.forward) ? 0 : resultRows.length - 1;
 
     // If the first result in the list was highlighted,
     // a 'forward' key moves the highlight to the 2nd result in the list,
@@ -226,33 +225,43 @@ HighlightManager.prototype = {
     // visible, else to the last result in the list.
     } else if (selectedIndex === 0) {
       if (evt.forward) {
-        this.popup.selectedIndex = 1;
+        this.popup.el.selectedIndex = 1;
       } else if (recommendationVisible) {
-        this.popup.selectedIndex = -1;
+        this.popup.el.selectedIndex = -1;
         this.recommendation.isHighlighted = true;
       } else {
-        this.popup.selectedIndex = resultRows.length - 1;
+        this.popup.el.selectedIndex = resultRows.length - 1;
       }
 
     // If the last result in the list was highlighted,
-    // a 'forward' key moves the highlight to the recommendation, if it's
-    // visible, else to the first result;
     // a 'backward' key moves the highlight to the result 2nd from the end
-    // of the list.
+    // of the list,
+    // a 'forward' key moves the highlight to the recommendation or the top
+    // result. We want to scroll to the top of the results list in either case,
+    // but scrolling the results list causes it to take the highlight. This
+    // complicates the case where we want to highlight the recommendation:
+    //   1. We use stealHighlight() to take the highlight, then retake it from
+    //      the results list on the following turn.
+    //   2. Unfortunately, if the mouse pointer is over the popup when the
+    //      results list scrolls to the top, a mousemove event will be fired,
+    //      causing the recommendation to lose the highlight again. To work
+    //      around this, we set some state on the popup, instructing it to
+    //      ignore the next mousemove event.
     } else if (selectedIndex === listLength - 1) {
       if (evt.forward && recommendationVisible) {
-        this.popup.selectedIndex = -1;
-        this.recommendation.isHighlighted = true;
+        this.popup.ignoreNextMouseOver = true;
+        resultsContainer.ensureIndexIsVisible(0);
+        this.stealHighlight();
       } else if (evt.forward && !recommendationVisible) {
-        this.popup.selectedIndex = 0;
+        this.popup.el.selectedIndex = 0;
       } else {
-        this.popup.selectedIndex = selectedIndex - 1;
+        this.popup.el.selectedIndex = selectedIndex - 1;
       }
 
     // If the highlighted result was in the middle of the list,
     // then move the highlight to one of its neighbors.
     } else {
-      this.popup.selectedIndex = evt.forward ? selectedIndex + 1 : selectedIndex - 1;
+      this.popup.el.selectedIndex = evt.forward ? selectedIndex + 1 : selectedIndex - 1;
     }
   }
 };

--- a/lib/ui/highlight-manager.js
+++ b/lib/ui/highlight-manager.js
@@ -15,16 +15,21 @@ function HighlightManager(opts) {
   // this is a recommendation view, because the highlight
   // class manages passing focus between it and the list of results
   this.recommendation = opts.recommendation;
-  this.stealHighlightTimeout = null;
 
   this.adjustHighlight = this.adjustHighlight.bind(this);
-  this.stealHighlight = this.stealHighlight.bind(this);
-  this.mutationHandler = this.mutationHandler.bind(this);
+  this.clearRecommendationHighlight = this.clearRecommendationHighlight.bind(this);
   this.initMutationObserver = this.initMutationObserver.bind(this);
+  this.mutationHandler = this.mutationHandler.bind(this);
+  this.onRecommendationMouseEnter = this.onRecommendationMouseEnter.bind(this);
+  this.onRecommendationMouseLeave = this.onRecommendationMouseLeave.bind(this);
+  this.onRecommendationMouseMove = this.onRecommendationMouseMove.bind(this);
+  this.stealHighlight = this.stealHighlight.bind(this);
 }
 
 HighlightManager.prototype = {
   init: function() {
+    this.popup = this.win.document.getElementById('PopupAutoCompleteRichResult');
+
     this.events.subscribe('navigational-key', this.adjustHighlight);
     // It seems that the recommendation is rarely in the XUL DOM when this init
     // function runs, so listen for the recommendation to be found in the DOM,
@@ -32,29 +37,92 @@ HighlightManager.prototype = {
     this.events.subscribe('recommendation-created', this.initMutationObserver);
     this.events.subscribe('recommendation-shown', this.stealHighlight);
 
-    this.popup = this.win.document.getElementById('PopupAutoCompleteRichResult');
-
+    this.attachMouseListeners();
     this.initMutationObserver();
   },
   destroy: function() {
     this.resultsObserver.disconnect();
+    this.detachMouseListeners();
+
     this.events.unsubscribe('recommendation-shown', this.stealHighlight);
     this.events.unsubscribe('navigational-key', this.adjustHighlight);
+
     delete this.popup;
-    delete this.recommendationView;
+    delete this.recommendation;
     delete this.win;
   },
+  attachMouseListeners: function() {
+    // This function is important because it gathers docs for all the mouse
+    // event handlers in a single place.
+
+    // When the user mouses into the recommendation, the results list might
+    // have had the focus, so swap the highlight. No need to resort to stealing
+    // the highlight, because there's no race to update the DOM.
+    this.events.subscribe('recommendation-mouseenter', this.onRecommendationMouseEnter);
+
+    // The mouseenter listener fails to apply the highlight to the
+    // recommendation in edge cases where the highlight is applied to the
+    // results list when the mouse pointer is inside the recommendation. When
+    // the user starts moving the mouse, no mouseenter event is fired, because
+    // the mouse pointer was already inside the element. This most often
+    // happens when the stealHighlight() method fails to steal the highlight
+    // (stealHighlight is non-deterministic), but can also reproducibly occur
+    // in flows like this example:
+    // 1. User mouses over the recommendation, highlighting it
+    // 2. User keys away from the recommendation, highlighting a result in the
+    //    results list
+    // 3. User wiggles the mouse inside the recommendation: no mouseenter is
+    //    fired, so no highlight is applied without a mousemove listener.
+    //
+    // While this is an edge case, the listener is simple, and makes the mouse
+    // highlight management code very robust against timing errors.
+    this.events.subscribe('recommendation-mousemove', this.onRecommendationMouseMove);
+
+    // When the user mouses out of the recommendation, if the mouse is leaving
+    // the popup, keep the recommendation highlighted, matching the mouseout
+    // behavior of the results list. If the mouse is moving to the results
+    // list, remove the highlight from the recommendation.
+    this.events.subscribe('recommendation-mouseleave', this.onRecommendationMouseLeave);
+
+    // When the user mouses over the results list, the recommendation may have
+    // the highlight, and should lose the highlight. This happens if the user
+    // mouses directly into the results list from outside the popup.
+    this.events.subscribe('results-list-mouse-highlighted', this.clearRecommendationHighlight);
+  },
+  detachMouseListeners: function() {
+    this.events.unsubscribe('recommendation-mouseenter', this.stealHighlight);
+    this.events.unsubscribe('recommendation-mouseleave', this.onRecommendationMouseLeave);
+    this.events.unsubscribe('recommendation-mousemove', this.onRecommendationMouseMove);
+    this.events.unsubscribe('results-list-mouse-highlighted', this.clearRecommendationHighlight);
+  },
+  onRecommendationMouseEnter: function() {
+    // See attachMouseListeners() for documentation.
+    this.popup.el.richlistbox.selectedIndex = -1;
+    this.recommendation.isHighlighted = true;
+  },
+  onRecommendationMouseMove: function() {
+    // See attachMouseListeners() for documentation.
+    this.popup.el.richlistbox.selectedIndex = -1;
+    this.recommendation.isHighlighted = true;
+  },
+  onRecommendationMouseLeave: function(evt) {
+    // See attachMouseListeners() for documentation.
+
+    // relatedTarget seems to be null when the user mouses out of the popup,
+    // even though the pointer may be entering other parts of the XUL DOM.
+    if (evt.relatedTarget && evt.relatedTarget.closest('.autocomplete-richlistbox')) {
+      this.recommendation.isHighlighted = false;
+    }
+  },
   initMutationObserver: function() {
-    // The existing code doesn't insert all the results at once; instead, rows
-    // are inserted after repeated timeouts, to keep the urlbar responsive (see
-    // _appendResultTimeout in autocomplete.xml). Each time some rows are
-    // inserted, the existing code reapplies the highlight to an item in the
-    // results list. So, as that happens, we want to continually steal the
-    // highlight back.
-    // The simplest way to do this, it turns out, is with a MutationObserver.
+    // Use a MutationObserver to detect when results are inserted into the
+    // popup. Unfortunately, while the history and suggestions searches return
+    // results async, there's no clean way to detect new results in pure JS.
+    //
     // Listen for changes to the `url` attribute on the rows inside the results
     // richlistbox. This ensures changes are detected, even when rows are
-    // reused, rather than created (see _adjustAcItem in autocomplete.xml).
+    // reused, rather than created (see the use of maxRows in _adjustAcItem,
+    // inside autocomplete.xml).
     this.resultsObserver = new this.win.MutationObserver(this.mutationHandler);
     const results = this.win.document.getAnonymousElementByAttribute(this.popup, 'anonid', 'richlistbox');
     const resultsObserverConfig = {
@@ -73,10 +141,10 @@ HighlightManager.prototype = {
   },
   stealHighlight: function() {
     // Retake control of the highlight under two circumstances:
-    // - when the recommendation has just been shown, if the user isn't keying
+    // 1. When the recommendation has just been shown, if the user isn't keying
     //   through the list already, then move the highlight from the top results
-    //   list item to the recommendation;
-    // - when a few results have been inserted into the DOM, causing the Gecko
+    //   list item to the recommendation.
+    // 2. When a few results have been inserted into the DOM, causing the Gecko
     //   code to move the highlight, steal it back.
     //
     // The existing XBL code batches insertions in timeouts. By default,
@@ -113,9 +181,12 @@ HighlightManager.prototype = {
     });
   },
   clearHighlight: function() {
-    const resultsContainer = this.win.document.getAnonymousElementByAttribute(this.popup, 'anonid', 'richlistbox');
-    const resultRows = resultsContainer.getElementsByClassName('autocomplete-richlistitem');
-    Array.prototype.forEach.call(resultRows, row => { row.selected = false; });
+    this.popup.richlistbox.selectedIndex = -1;
+    this.recommendation.isHighlighted = false;
+  },
+  clearRecommendationHighlight: function() {
+    // See attachMouseListeners() for documentation.
+    this.recommendation.isHighlighted = false;
   },
   adjustHighlight: function(evt) {
     // Due to constraints in combining XBL and JS, we have to totally take over

--- a/lib/ui/popup.js
+++ b/lib/ui/popup.js
@@ -11,8 +11,10 @@ function Popup(opts) {
   */
   this.win = opts.win;
   this.events = opts.events;
+  this.mouseOverTimeout = null;
 
   this.beforePopupHide = this.beforePopupHide.bind(this);
+  this.onResultsMouseOver = this.onResultsMouseOver.bind(this);
 }
 
 Popup.prototype = {
@@ -22,5 +24,23 @@ Popup.prototype = {
   },
   beforePopupHide: function(evt) {
     this.events.publish('before-popup-hide');
+  },
+  onResultsMouseOver: function(evt) {
+    if (this.ignoreNextMouseOver) {
+      this.ignoreNextMouseOver = false;
+      return;
+    }
+
+    // Throttle mouseover events, which fire rapidly if the user quickly moves
+    // the mouse across different DOM elements in the results list.
+    if (this.mouseOverTimeout) {
+      return;
+    }
+    this.mouseOverTimeout = this.win.setTimeout(() => {
+      this.win.clearTimeout(this.mouseOverTimeout);
+      this.mouseOverTimeout = null;
+    }, 15);
+
+    this.events.publish('results-list-mouse-highlighted');
   }
 };

--- a/lib/ui/popup.js
+++ b/lib/ui/popup.js
@@ -13,6 +13,11 @@ function Popup(opts) {
   this.events = opts.events;
   this.mouseOverTimeout = null;
 
+  // Public property used when we need to ignore a single mouseover event,
+  // due to the mouse pointer being positioned over the popup when the results
+  // list scrolls itself. See HighlightManager for more.
+  this.ignoreNextMouseOver = false;
+
   this.beforePopupHide = this.beforePopupHide.bind(this);
   this.onResultsMouseOver = this.onResultsMouseOver.bind(this);
 }

--- a/lib/ui/popup.js
+++ b/lib/ui/popup.js
@@ -27,6 +27,14 @@ Popup.prototype = {
     this.el = this.win.document.getElementById('PopupAutoCompleteRichResult');
     this.el.addEventListener('popuphiding', this.beforePopupHide);
   },
+  destroy: function() {
+    this.el.removeEventListener('popuphiding', this.beforePopupHide);
+
+    this.win.clearTimeout(this.mouseOverTimeout);
+
+    delete this.el;
+    delete this.win;
+  },
   beforePopupHide: function(evt) {
     this.events.publish('before-popup-hide');
   },

--- a/lib/ui/recommendation.js
+++ b/lib/ui/recommendation.js
@@ -16,6 +16,7 @@ function Recommendation(opts) {
   this.el = null;
   this.timeout = null;
   this.RecommendationRow = opts.RecommendationRow;
+  this.mouseMoveTimeout = null;
 
   Object.defineProperty(this, 'isHighlighted', {
     get: () => {
@@ -37,6 +38,9 @@ function Recommendation(opts) {
   this.show = this.show.bind(this);
   this.hide = this.hide.bind(this);
   this._pollForElement = this._pollForElement.bind(this);
+  this.onMouseEnter = this.onMouseEnter.bind(this);
+  this.onMouseMove = this.onMouseMove.bind(this);
+  this.onMouseLeave = this.onMouseLeave.bind(this);
 }
 
 Recommendation.prototype = {
@@ -44,37 +48,71 @@ Recommendation.prototype = {
     // Note: the XUL DOM isn't updated to insert the
     // 'universal-search-recommendation' element until the popup is opened
     // once. So, poll for the element until it's ready, then attach listeners
-    // to it.
-    this._pollForElement();
+    // to it, and notify the HighlightManager that the recommendation has
+    // been created.
+    this._pollForElement(() => {
+      this.attachListeners();
+      this.events.publish('recommendation-created');
+    });
 
     this.events.subscribe('recommendation', this.show);
     this.events.subscribe('enter-key', this.navigate);
     this.events.subscribe('urlbar-change', this.hide);
     this.events.subscribe('before-popup-hide', this.hide);
   },
-
-  destroy: function() {
+  attachListeners: function() {
+    this.el.addEventListener('click', this.navigate);
+    this.el.addEventListener('mouseenter', this.onMouseEnter);
+    this.el.addEventListener('mousemove', this.onMouseMove);
+    this.el.addEventListener('mouseleave', this.onMouseLeave);
+  },
+  detachListeners: function() {
     this.el.removeEventListener('click', this.navigate);
+    this.el.removeEventListener('mouseenter', this.onMouseEnter);
+    this.el.removeEventListener('mousemove', this.onMouseMove);
+    this.el.removeEventListener('mouseleave', this.onMouseLeave);
+  },
+  destroy: function() {
+    this.detachListeners();
     this.events.unsubscribe('recommendation', this.show);
     this.events.unsubscribe('enter-key', this.navigate);
     this.events.unsubscribe('urlbar-change', this.hide);
     this.events.unsubscribe('before-popup-hide', this.hide);
 
+    this.win.clearTimeout(this.mouseMoveTimeout);
+
     delete this.el;
     delete this.win;
   },
-
-  _pollForElement: function() {
+  _pollForElement: function(cb) {
     const el = this.win.document.getElementById(RECOMMENDATION_ID);
     if (el) {
       this.el = el;
-      this.el.addEventListener('click', this.navigate);
-      this.events.publish('recommendation-created');
+      cb();
     } else {
-      this.win.setTimeout(this._pollForElement, 75);
+      this.win.setTimeout(() => { this._pollForElement(cb) }, 75);
     }
   },
+  onMouseEnter: function(evt) {
+    this.events.publish('recommendation-mouseenter', evt);
+  },
+  onMouseLeave: function(evt) {
+    this.events.publish('recommendation-mouseleave', evt);
+  },
+  onMouseMove: function(evt) {
 
+    // Throttle mousemove events so they fire immediately, then no more often
+    // than every 30 ms (may be longer than 30 ms due to event loop delays).
+    if (this.mouseMoveTimeout) {
+      return;
+    }
+    this.mouseMoveTimeout = this.win.setTimeout(() => {
+      this.win.clearTimeout(this.mouseMoveTimeout);
+      this.mouseMoveTimeout = null;
+    }, 30);
+
+    this.events.publish('recommendation-mousemove', evt);
+  },
   show: function(data) {
     if (this.timeout) {
       this.win.clearTimeout(this.timeout);
@@ -96,7 +134,6 @@ Recommendation.prototype = {
       this.events.publish('recommendation-shown', this);
     }
   },
-
   hide: function() {
     if (this.el) {
       const container = this.win.document.getElementById(RECOMMENDATION_ID);
@@ -106,7 +143,6 @@ Recommendation.prototype = {
       this.data = null;
     }
   },
-
   navigate: function(evt) {
     // if it's a click, we'll have a MouseEvent; if it's a right-click, bail.
     // else, we'll just have the (possibly null) data from the 'enter-key' event.

--- a/lib/universal-search.js
+++ b/lib/universal-search.js
@@ -175,18 +175,19 @@ Search.prototype = {
     });
     app.urlbar.init();
 
-    app.highlightManager = new app.HighlightManager({
-      win: win,
-      events: app.events,
-      recommendation: app.recommendation
-    });
-    app.highlightManager.init();
-
     app.popup = new app.Popup({
       win: win,
       events: app.events
     });
     app.popup.init();
+
+    app.highlightManager = new app.HighlightManager({
+      win: win,
+      events: app.events,
+      recommendation: app.recommendation,
+      popup: app.popup
+    });
+    app.highlightManager.init();
   },
 
   _stopApp: function(win) {


### PR DESCRIPTION
@chuckharmston R?

The mouse highlight logic is collected in the HighlightManager's attachMouseListeners method, and should hopefully be fairly readable.

On a very happy side note, I discovered that leaving the `selectedIndex` state where it was originally (on the results list) lets us remove 95% of the XBL code introduced in the key focus PR! :tada: :fireworks:

This code might be slightly easier to read if you go through it commit by commit. I'll point out a few changes that fixed unrelated bugs/typos I noticed while in the code.
