### PR TITLE
Changes recommendation label to semi-transparent white (closes #83).

### DIFF
--- a/chrome/skin/style.css
+++ b/chrome/skin/style.css
@@ -147,3 +147,7 @@ textbox#urlbar {
 #universal-search-recommendation.highlight #universal-search-recommendation-url {
   color: HighlightText;
 }
+#universal-search-recommendation.highlight #universal-search-recommendation-label {
+  color: HighlightText;
+  opacity: 0.67;
+}


### PR DESCRIPTION
r? @6a68 
## Before

<img width="1048" alt="screen shot 2016-03-17 at 1 53 38 pm" src="https://cloud.githubusercontent.com/assets/23885/13859166/ae833fc8-ec47-11e5-82b3-94cc2dcdd596.png">
## After

<img width="1023" alt="screen shot 2016-03-17 at 1 45 35 pm" src="https://cloud.githubusercontent.com/assets/23885/13859145/8eefd932-ec47-11e5-8949-26d5c5703c86.png">
