### PR TITLE
Removes inset box-shadow from highlighted key image and logo (closes #84).

### DIFF
--- a/chrome/skin/style.css
+++ b/chrome/skin/style.css
@@ -155,3 +155,11 @@ popupset#mainPopupSet panel#PopupAutoCompleteRichResult richlistbox {
   color: HighlightText;
   opacity: 0.67;
 }
+#universal-search-recommendation.highlight #universal-search-recommendation-image {
+  background-color: #FFF;
+  box-shadow: 0;
+}
+#universal-search-recommendation.highlight #universal-search-recommendation-logo,
+#universal-search-recommendation.highlight #universal-search-recommendation-keyimage {
+  z-index: 1;
+}


### PR DESCRIPTION
r? @6a68 
## Before

<img width="326" alt="screen shot 2016-03-17 at 1 58 27 pm" src="https://cloud.githubusercontent.com/assets/23885/13859290/5c1e80b6-ec48-11e5-87bd-67a5decaba51.png">
## After

<img width="253" alt="screen shot 2016-03-17 at 1 56 20 pm" src="https://cloud.githubusercontent.com/assets/23885/13859258/373db62c-ec48-11e5-9f08-b30534fcf281.png">

<img width="316" alt="screen shot 2016-03-17 at 1 56 24 pm" src="https://cloud.githubusercontent.com/assets/23885/13859263/3c2226dc-ec48-11e5-9f8d-e2b99b406930.png">

_NB: Google's image has a transparent background._
