### PR TITLE
Uses 2x resolution default favicon (closes #102).

### DIFF
--- a/lib/ui/recommendation-row.js
+++ b/lib/ui/recommendation-row.js
@@ -50,7 +50,7 @@ RecommendationRow.prototype = {
     Firefox's default favicon.
     */
     let favicon = row._get('enhancements.embedly.favicon.url');
-    let defaultFavicon = 'moz-anno:favicon:http://www.mozilla.org/2005/made-up-favicon';
+    let defaultFavicon = 'chrome://mozapps/skin/places/defaultFavicon@2x.png';
     let elem = createElement(row.doc, 'image', 'favicon');
     elem.setAttribute('src', favicon ? favicon : defaultFavicon);
     elem.onerror = function(evt) {


### PR DESCRIPTION
Actually, there may be a reason to use it: the browser doesn't appear to use the 2x icon, and the difference is a little bit jarring:

<img width="358" alt="screen shot 2016-03-23 at 9 34 44 am 2" src="https://cloud.githubusercontent.com/assets/23885/13990699/dff49bf0-f0da-11e5-9121-883e5a1d1876.png">

Thoughts @6a68? Feel free to merge or close, I'm fine with either.
