### PR TITLE
Uses data from favicon classifier (closes #109).

### DIFF
--- a/lib/ui/recommendation-row.js
+++ b/lib/ui/recommendation-row.js
@@ -49,7 +49,7 @@ RecommendationRow.prototype = {
     available, or if the URL returned from the server errors, will use
     Firefox's default favicon.
     */
-    let favicon = row._get('enhancements.embedly.favicon.url');
+    let favicon = row._get('enhancements.favicon.url');
     let defaultFavicon = 'chrome://mozapps/skin/places/defaultFavicon@2x.png';
     let elem = createElement(row.doc, 'image', 'favicon');
     elem.setAttribute('src', favicon ? favicon : defaultFavicon);
@@ -204,11 +204,11 @@ RecommendationRow.prototype = {
     favicon. If the brightness of that value is greater than 75%, the
     foreground is black. Otherwise, it is white.
     */
-    let colors = row._get('enhancements.embedly.favicon.colors');
-    if (colors && colors.length) {
-      const r = colors[0].color[0];
-      const g = colors[0].color[1];
-      const b = colors[0].color[2];
+    let color = row._get('enhancements.favicon.color');
+    if (color) {
+      const r = color[0];
+      const g = color[1];
+      const b = color[2];
       const brightness = ((r * 0.2126 + g * 0.7152 + b * 0.0722) / 255);
       return {
         'background': `rgb(${r}, ${g}, ${b})`,


### PR DESCRIPTION
r? @6a68 

<img width="153" alt="screen shot 2016-03-24 at 4 27 01 pm" src="https://cloud.githubusercontent.com/assets/23885/14033120/5c8f0350-f1dd-11e5-8293-4102ec81e256.png">

Note both that the favicon is present, and the letterbox picks up the dominant color from the favicon.
