### PR TITLE
When the user types, highlight the urlbar, not the recommendation

### DIFF
--- a/lib/ui/highlight-manager.js
+++ b/lib/ui/highlight-manager.js
@@ -139,15 +139,21 @@ HighlightManager.prototype = {
     }
   },
   stealHighlight: function() {
-    // Retake control of the highlight under two circumstances:
+    // If the recommendation is shown, the default behavior is for the urlbar
+    // to have the highlight. That is, neither the recommendation nor any items
+    // in the results list should be highlighted.
+    //
+    // We need to retake control of the highlight under two circumstances:
     // 1. When the recommendation has just been shown, if the user isn't keying
-    //   through the list already, then move the highlight from the top results
-    //   list item to the recommendation.
-    // 2. When a few results have been inserted into the DOM, causing the Gecko
-    //   code to move the highlight, steal it back.
+    //    through the list already, then move the highlight from the top results
+    //    list item to the urlbar.
+    // 2. After (1), when a few more results have been inserted into the DOM,
+    //    the Gecko code will take the highlight again; steal it back.
     //
     // The existing XBL code batches insertions in timeouts. By default,
-    // 30 rows are inserted in groups of 6, invoking setTimeout 5 times.
+    // the code invokes setTimeout 5 times, inserting 6 rows per turn, up
+    // to the default max of 30 rows.
+    //
     // Because the event loop already has up to 5 timers waiting, we can't
     // rely on setTimeout to steal the highlight: our request will be queued
     // behind all those other timers, causing a noticeably long flicker of the
@@ -155,27 +161,25 @@ HighlightManager.prototype = {
     //
     // Our workaround relies on using requestAnimationFrame to cut in line,
     // interleaving our highlight stealing between the setTimeouts.
+    //
     // Specifically, each time stealHighlight is called (in response to a DOM
     // mutation fired when rows are inserted into the list), we ask the browser
     // to steal the highlight three times: immediately, just before the next
     // frame is painted (the outer rAF), and just before the frame after that
     // (the inner rAF).
     //
-    // This is a weird hack, but it works fairly well; because setTimeout makes
+    // This is a weird hack, but it works fairly well. Because setTimeout makes
     // no guarantees about precisely when a callback will be executed, and
     // because the row insertion timeouts are called closely together, ours is
     // a pretty good, though nondeterministic, solution.
     if (!this.recommendation.el || this.recommendation.el.collapsed) {
       return;
     }
-    this.recommendation.isHighlighted = true;
-    this.popup.el.selectedIndex = -1;
+    this.clearHighlight();
     this.win.requestAnimationFrame(() => {
-      this.recommendation.isHighlighted = true;
-      this.popup.el.selectedIndex = -1;
+      this.clearHighlight();
       this.win.requestAnimationFrame(() => {
-        this.recommendation.isHighlighted = true;
-        this.popup.el.selectedIndex = -1;
+        this.clearHighlight();
       });
     });
   },
@@ -199,93 +203,133 @@ HighlightManager.prototype = {
 
     // Batch all DOM access here at the start of the function.
     const resultsContainer = this.win.document.getAnonymousElementByAttribute(this.popup.el, 'anonid', 'richlistbox');
-    const resultRows = resultsContainer.getElementsByClassName('autocomplete-richlistitem');
-    // resultRows is a live collection, and the XBL code inserts elements over
-    // several turns, so we'll use listLength for calculating the past state
-    // of the world, but when we want to assign focus to the last item in the
-    // list, we'll use the live collection.
+    const resultRows = resultsContainer.querySelectorAll('.autocomplete-richlistitem:not([collapsed])');
+    const recommendationUrl = this.recommendation.el.querySelector('#universal-search-recommendation-url');
     const listLength = resultRows.length;
     const selectedIndex = this.popup.el.selectedIndex;
     const recommendationVisible = this.recommendation.el && !this.recommendation.el.collapsed;
     const recommendationHighlighted = this.recommendation.el && this.recommendation.isHighlighted;
-    // To update the urlbar contents quickly, we'll keep track of the new
-    // index that's gaining focus, grab its url, and pass it to the urlbar.
+
+    // Here's where we will temporarily store the state updates that we'll
+    // actually make at the end:
+    //
+    // newIndex gives the new index that should be highlighted in the results
+    // list, or -1 if the list shouldn't be highlighted.
     let newIndex;
+    // newUrl is the URL of the new item. It's set in the urlbar as part of
+    // the highlight update.
+    let newUrl;
+    // Also keep track of what we want to do next with the recommendation.
+    let shouldHighlightRecommendation;
 
     // Clear all highlights. The DOM is now dirty and not trustworthy.
     this.clearHighlight();
 
+    // Now, we look at the state of the recommendation and the results list,
+    // and decide what should be highlighted next.
+
+    // These utility functions abstract out the state changes, and make the
+    // state transition logic more readable.
+    function highlightUrlbar() {
+      shouldHighlightRecommendation = false;
+      newIndex = -1;
+      newUrl = null;
+    }
+
+    function highlightRecommendation() {
+      shouldHighlightRecommendation = true;
+      newIndex = -1;
+      newUrl = recommendationUrl.getAttribute('data-url');
+    }
+
+    function highlightResult(index) {
+      shouldHighlightRecommendation = false;
+      newIndex = index;
+      newUrl = resultRows[newIndex].getAttribute('url');
+    }
+
+    function highlightFirstResult() {
+      highlightResult(0);
+    }
+
+    function highlightLastResult() {
+      highlightResult(resultRows.length - 1);
+    }
+
+    // If the urlbar has focus,
+    // a 'forward' key moves the highlight to the recommendation, if it's
+    // visible, or else the first result;
+    // a 'backward' key moves the highlight to the bottom of the list.
+    if (!recommendationHighlighted && selectedIndex === -1) {
+      if (evt.forward) {
+        recommendationVisible ? highlightRecommendation() : highlightFirstResult();
+      } else {
+        highlightLastResult();
+      }
+
     // If the recommendation was highlighted,
     // a 'forward' key moves the highlight to the first result in the list,
-    // a 'backward' key moves the highlight to the bottom of the list.
-    if (recommendationHighlighted) {
-      this.recommendation.isHighlighted = false;
-      newIndex = (evt.forward) ? 0 : resultRows.length - 1;
-      this.popup.el.selectedIndex = newIndex;
+    // a 'backward' key moves the highlight to the urlbar.
+    } else if (recommendationHighlighted) {
+      if (evt.forward) {
+        highlightFirstResult();
+      } else {
+        highlightUrlbar();
+      }
 
     // If the first result in the list was highlighted,
     // a 'forward' key moves the highlight to the 2nd result in the list,
     // a 'backward' key moves the highlight to the recommendation, if it's
-    // visible, else to the last result in the list.
+    // visible, or else to the urlbar.
     } else if (selectedIndex === 0) {
       if (evt.forward) {
-        newIndex = 1;
-      } else if (recommendationVisible) {
-        newIndex = -1;
-        this.recommendation.isHighlighted = true;
+        highlightResult(1);
       } else {
-        newIndex = resultRows.length - 1;
+        recommendationVisible ? highlightRecommendation() : highlightUrlbar();
       }
-      this.popup.el.selectedIndex = newIndex;
 
     // If the last result in the list was highlighted,
+    // a 'forward' key moves the highlight to the urlbar, scrolling the
+    // results list back to the first item,
     // a 'backward' key moves the highlight to the result 2nd from the end
-    // of the list,
-    // a 'forward' key moves the highlight to the recommendation or the top
-    // result. We want to scroll to the top of the results list in either case,
-    // but scrolling the results list causes it to take the highlight. This
-    // complicates the case where we want to highlight the recommendation:
-    //   1. We use stealHighlight() to take the highlight, then retake it from
-    //      the results list on the following turn.
-    //   2. Unfortunately, if the mouse pointer is over the popup when the
-    //      results list scrolls to the top, a mousemove event will be fired,
-    //      causing the recommendation to lose the highlight again. To work
-    //      around this, we set some state on the popup, instructing it to
-    //      ignore the next mousemove event.
+    // of the list.
+    //
+    // It turns out that scrolling the results list (the 'forward' case)
+    // causes the results list to retake the highlight. If the recommendation
+    // is shown, we want to steal the highlight back for the urlbar. (If not,
+    // the top result item will be highlighted, the expected behavior.)
+    //
+    // An additional complication: if the mouse pointer is over the popup when
+    // the results list scrolls, a mouseover event will be fired on the result
+    // that's scrolled underneath the mouse pointer. We want to ignore this
+    // event, whether or not the recommendation is visible, so ask the popup
+    // to ignore the very next mouseover event it receives.
     } else if (selectedIndex === listLength - 1) {
-      if (evt.forward && recommendationVisible) {
+      if (evt.forward) {
+        if (recommendationVisible) {
+          this.stealHighlight();
+        }
         this.popup.ignoreNextMouseOver = true;
         resultsContainer.ensureIndexIsVisible(0);
-        this.stealHighlight();
-        newIndex = -1;
-      } else if (evt.forward && !recommendationVisible) {
-        newIndex = 0;
+        highlightUrlbar();
       } else {
-        newIndex = selectedIndex - 1;
+        highlightResult(selectedIndex - 1);
       }
-      this.popup.el.selectedIndex = newIndex;
 
     // If the highlighted result was in the middle of the list,
     // then move the highlight to one of its neighbors.
     } else {
-      newIndex = evt.forward ? selectedIndex + 1 : selectedIndex - 1;
-      this.popup.el.selectedIndex = newIndex;
+      if (evt.forward) {
+        highlightResult(selectedIndex + 1);
+      } else {
+        highlightResult(selectedIndex - 1);
+      }
     }
 
-    // Finally, figure out the new url, and tell the urlbar that the selection
-    // has changed.
-    let newUrl;
-    if (newIndex === -1) {
-      let urlEl = this.recommendation.el.querySelector('#universal-search-recommendation-url');
-      newUrl = urlEl && urlEl.getAttribute('data-url');
-    } else {
-      // The 'url' attribute is used by both history results and search
-      // suggestions, so it works whenever the recommendation isn't selected.
-      newUrl = resultRows[newIndex] && resultRows[newIndex].getAttribute('url');
-    }
-    // Only fire the change event if we really found a new URL in the DOM.
-    if (newUrl) {
-      this.events.publish('selection-change', { newUrl: newUrl });
-    }
+    // Now that we've figured out which item will take the highlight,
+    // update the DOM, and fire a signal that sets the newUrl in the urlbar.
+    this.popup.el.selectedIndex = newIndex;
+    this.recommendation.isHighlighted = shouldHighlightRecommendation;
+    this.events.publish('selection-change', { newUrl: newUrl });
   }
 };

--- a/lib/ui/urlbar.js
+++ b/lib/ui/urlbar.js
@@ -33,9 +33,10 @@ Urlbar.prototype = {
     delete this.el;
     delete this.win;
   },
+  // Set the URL in the urlbar to data.newUrl, if it's defined;
+  // otherwise, reset the URL to the actual value the user typed.
   updateTextValue: function(data) {
-    // Just keep the smarts in the highlight manager.
-    this.win.gURLBar.textValue = data.newUrl;
+    this.win.gURLBar.textValue = data.newUrl || this.win.gBrowser.userTypedValue;
   },
   // Return `true` to prevent the existing Gecko key handler code from running.
   onKeyPress: function(evt) {


### PR DESCRIPTION
@chuckharmston R? Modified the highlight manager logic to put the focus in the urlbar (i.e., not highlight the recommendation or the results list) whenever the recommendation is visible. I wound up refactoring the highlight management logic, because it was a bit hard to puzzle through the cases as written. The [new version of the `HighlightManager.adjustHighlight` function](https://github.com/6a68/universal-search/blob/f407fa91db6cf9f5269d4fe43bf64596b3b35919/lib/ui/highlight-manager.js#L194) might be more readable than the unified diff. I rarely say this, but I'm actually pleased with how the code is shaping up ^_^

Desired behavior after applying this patch: when you type in the urlbar, if the recommendation is visible, neither the recommendation nor any results list item should have focus. The urlbar should appear to have focus.

The underlying reason for this change is that the highlighted thing should tell you what happens if you hit 'Enter', and we don't put the recommendation URL in the urlbar until you select it. In contrast, if the recommendation is not shown, the top results list item should be highlighted, because what it says (either 'search with &lt; search provider >' or 'visit &lt; url >' is actually what happens if you hit enter.

The rest of the commit message follows:
- Reorganize the highlight transition logic to be easier to read.
- The popup stores unused rows for later reuse, so only use visible
  rows for highlight transition calculations (fixes #112).

Fixes #96.
