### PR TITLE
Show recommendations in response to 'paste' events on the urlbar

### DIFF
--- a/lib/ui/urlbar.js
+++ b/lib/ui/urlbar.js
@@ -16,6 +16,7 @@ function Urlbar(opts) {
   this.recommendation = opts.recommendation;
 
   this.navigate = this.navigate.bind(this);
+  this.publishUrlbarUpdate = this.publishUrlbarUpdate.bind(this);
   this.updateTextValue = this.updateTextValue.bind(this);
 }
 
@@ -23,12 +24,16 @@ Urlbar.prototype = {
   init: function() {
     this.el = this.win.document.getElementById('urlbar');
 
+    this.win.gURLBar.addEventListener('paste', this.publishUrlbarUpdate);
+
     this.events.subscribe('recommendation-navigate', this.navigate);
     this.events.subscribe('selection-change', this.updateTextValue);
   },
   destroy: function() {
     this.events.unsubscribe('recommendation-navigate', this.navigate);
     this.events.unsubscribe('selection-change', this.updateTextValue);
+
+    this.win.gURLBar.removeEventListener('paste', this.publishUrlbarUpdate);
 
     delete this.el;
     delete this.win;
@@ -50,7 +55,7 @@ Urlbar.prototype = {
     // we also want the existing popup code to search history and fetch
     // suggestions with that keystroke.
     if (this.isPrintableKey(evt) || this.isDeleteKey(evt)) {
-      this.handlePrintableKey(evt);
+      this.publishUrlbarUpdate(evt);
     // If the popup is closed, the up and down arrows open it, and a slightly
     // different set of items is shown. In this case, we want the existing
     // code to handle the event, so return false.
@@ -79,12 +84,11 @@ Urlbar.prototype = {
     // also trigger a 'urlbar-change' event.
     return evt.key === 'Delete' || evt.key === 'Backspace';
   },
-  handlePrintableKey: function(evt) {
-    // We receive the key event before the corresponding character has been
-    // inserted into the urlbar. Rather than deal with checking the position of
-    // the caret, checking to see if there is a text selection in the urlbar
-    // that would be replaced by the string, and so on, we just set a timeout,
-    // give the browser a turn to update the string, and send that along.
+  publishUrlbarUpdate: function() {
+    // This function is called when we know the urlbar contents have been
+    // changed (by a printable key or a paste event), but we don't know what
+    // the new urlbar contents will be. Wait a turn, so the browser can update
+    // the UI, then get the updated urlbar contents and send along.
     //
     // Note also that the urlbar autocompletes strings to domains in history.
     // We don't want to send the autocompleted string (gURLBar.value), we want


### PR DESCRIPTION
@chuckharmston r?

Here's the rest of the commit message:

Note: trying to listen for 'cut' events on the urlbar didn't work at
all. It seems fairly unusual for part of the urlbar contents to be cut,
so rather than look for a comprehensive fix, just deciding to stick with
the simple, much more common case of paste support.

Fixes #68.
