### PR TITLE
Allow the popup to be opened by up or down arrows

### DIFF
--- a/lib/ui/urlbar.js
+++ b/lib/ui/urlbar.js
@@ -51,6 +51,12 @@ Urlbar.prototype = {
     // suggestions with that keystroke.
     if (this.isPrintableKey(evt) || this.isDeleteKey(evt)) {
       this.handlePrintableKey(evt);
+    // If the popup is closed, the up and down arrows open it, and a slightly
+    // different set of items is shown. In this case, we want the existing
+    // code to handle the event, so return false.
+    } else if (!this.win.gURLBar.popup.popupOpen &&
+              (evt.key === 'ArrowDown' || evt.key === 'ArrowUp')) {
+      return false;
     // If we get a navigational key, adjust the highlight.
     } else if (this.isNavigationalKey(evt)) {
       this.handleNavigationalKey(evt);


### PR DESCRIPTION
Fixes #113.

@chuckharmston r? You can test this by hitting the up or down arrows when the urlbar is focused, but the popup is not open.
