### PR TITLE
Don't steal highlight if user is interacting with the popup

### DIFF
--- a/lib/ui/highlight-manager.js
+++ b/lib/ui/highlight-manager.js
@@ -184,6 +184,11 @@ HighlightManager.prototype = {
     });
   },
   clearHighlight: function() {
+    // If the selectedIndex > 0, the user is keying through the list, so don't
+    // do anything to the highlight.
+    if (this.popup.el.richlistbox.selectedIndex > 0) {
+      return;
+    }
     this.popup.el.richlistbox.selectedIndex = -1;
     this.recommendation.isHighlighted = false;
   },


### PR DESCRIPTION
Fixes #85.

@chuckharmston R?

This is a fix for #85: if the recommendation arrives after the user has started keying through the popup, we shouldn't steal the highlight.

To make testing easier, you can wrap most of the body of the ui/recommendation `show` method in a one-second timeout (see the diff below). Once this is done, you can easily prove to yourself that the recommendation does steal the highlight, but not if you've started keying through the popup.

We're now adding a DOM state check inside our `requestAnimationFrame` callbacks, so there's potential here for the UI to become more sluggish. However, I'm not seeing any noticeable additional jank; let me know if you see strange artifacts or weird behavior.

``` diff
diff --git a/lib/ui/recommendation.js b/lib/ui/recommendation.js
index 555b48d..87b9d43 100644
--- a/lib/ui/recommendation.js
+++ b/lib/ui/recommendation.js
@@ -117,10 +117,13 @@ Recommendation.prototype = {
     this.events.publish('recommendation-mousemove', evt);
   },
   show: function(data) {
+    this.win.console.log('show called, waiting one second for highlight testing');
     if (this.timeout) {
       this.win.clearTimeout(this.timeout);
       this.timeout = null;
     }
+    this.win.setTimeout(() => {
+    this.win.console.log('delayed show now rendering recommendation');

     // Don't re-render the recommendation if the content hasn't changed since
     // the previous recommendation.
@@ -146,6 +149,8 @@ Recommendation.prototype = {
       this.data = data;
       this.events.publish('recommendation-shown', this);
     }
+
+    }, 1000);
   },
   hide: function() {
     if (this.el) {
```
