### PR TITLE
Simplify recommendation-row check for keys in server response

### DIFF
--- a/lib/ui/recommendation-row.js
+++ b/lib/ui/recommendation-row.js
@@ -180,11 +180,11 @@ RecommendationRow.prototype = {
     Attempt to return a value from the recommendation data at the passed key
     string. If not set, falsy, or an empty object, return null;
     */
-    const val = key.split('.').reduce(function(o, x) {
-      return (typeof o == 'undefined' || o === null) ? o : o[x];
-    }, this._data);
-    const isEmptyObject = (typeof val == 'object' && !Object.keys(val).length);
-    return (typeof val == 'undefined' || !val || isEmptyObject) ? null : val;
+    let val;
+    try {
+      val = this._data[key];
+    } catch (ex) {}
+    return val;
   },
 
   _firstLetterInBaseDomain: function(row) {


### PR DESCRIPTION
Fixes #87 

@chuckharmston R?

I found my way to this line in the course of debugging a few weeks ago, but I don't know what the symptom was.

At any rate, the `_get` method is called in a lot of places, and it looked pretty formidable as written. Adjusting to use a simpler approach.
