### PR TITLE
Revert "Hide recommendation if it duplicates an existing result"

### DIFF
--- a/lib/ui/highlight-manager.js
+++ b/lib/ui/highlight-manager.js
@@ -114,9 +114,6 @@ HighlightManager.prototype = {
     }
   },
   initMutationObserver: function() {
-    // TODO: Let's move the MutationObserver code to the popup, exposing the
-    // updates to the rest of the app via pubsub events. (#135)
-    //
     // Use a MutationObserver to detect when results are inserted into the
     // popup. Unfortunately, while the history and suggestions searches return
     // results async, there's no clean way to detect new results in pure JS.
@@ -126,13 +123,14 @@ HighlightManager.prototype = {
     // reused, rather than created (see the use of maxRows in _adjustAcItem,
     // inside autocomplete.xml).
     this.resultsObserver = new this.win.MutationObserver(this.mutationHandler);
+    const results = this.win.document.getAnonymousElementByAttribute(this.popup.el, 'anonid', 'richlistbox');
     const resultsObserverConfig = {
       childList: true,
       subtree: true,
       attributes: true,
       attributeFilter: ['url']
     };
-    this.resultsObserver.observe(this.popup.el.richlistbox, resultsObserverConfig);
+    this.resultsObserver.observe(results, resultsObserverConfig);
   },
   mutationHandler: function() {
     // If the recommendation exists and is visible, steal the highlight.
@@ -209,7 +207,7 @@ HighlightManager.prototype = {
     // batching reads and writes, rather than interleaving them.
 
     // Batch all DOM access here at the start of the function.
-    const resultsContainer = this.popup.el.richlistbox;
+    const resultsContainer = this.win.document.getAnonymousElementByAttribute(this.popup.el, 'anonid', 'richlistbox');
     const resultRows = resultsContainer.querySelectorAll('.autocomplete-richlistitem:not([collapsed])');
     const recommendationUrl = this.recommendation.el.querySelector('#universal-search-recommendation-url');
     const listLength = resultRows.length;

--- a/lib/ui/popup.js
+++ b/lib/ui/popup.js
@@ -11,11 +11,7 @@ function Popup(opts) {
   */
   this.win = opts.win;
   this.events = opts.events;
-  this.eTLD = opts.eTLD;
-  this.io = opts.io;
   this.mouseOverTimeout = null;
-
-  this.resultsContainer = null;
 
   // Public property used when we need to ignore a single mouseover event,
   // due to the mouse pointer being positioned over the popup when the results
@@ -24,29 +20,20 @@ function Popup(opts) {
 
   this.beforePopupHide = this.beforePopupHide.bind(this);
   this.onResultsMouseOver = this.onResultsMouseOver.bind(this);
-  this.onPopupReady = this.onPopupReady.bind(this);
 }
 
 Popup.prototype = {
   init: function() {
     this.el = this.win.document.getElementById('PopupAutoCompleteRichResult');
     this.el.addEventListener('popuphiding', this.beforePopupHide);
-    // Assign this.resultsContainer once the popup has rendered.
-    this.events.subscribe('recommendation-created', this.onPopupReady);
   },
   destroy: function() {
     this.el.removeEventListener('popuphiding', this.beforePopupHide);
-    this.events.unsubscribe('recommendation-created', this.onPopupReady);
 
     this.win.clearTimeout(this.mouseOverTimeout);
 
-    delete this.resultsContainer;
     delete this.el;
     delete this.win;
-  },
-  onPopupReady: function() {
-    this.events.unsubscribe('recommendation-created', this.onPopupReady);
-    this.resultsContainer = this.el.richlistbox;
   },
   beforePopupHide: function(evt) {
     this.events.publish('before-popup-hide');
@@ -68,61 +55,5 @@ Popup.prototype = {
     }, 15);
 
     this.events.publish('results-list-mouse-highlighted');
-  },
-  domainVisible: function(recommendationUrl) {
-    // The domainVisible method checks if the recommendationUrl's *domain*
-    // matches the domain of at least one result in the first page of results
-    // in the popup. (There can be up to 6 items shown in the popup without
-    // scrolling.)
-    //
-    // Return true if a visible result has the same domain as the
-    // recommendationUrl. Otherwise, return undefined.
-
-    // If the popup hasn't been shown yet, there won't be results to compare
-    // against.
-    if (!this.resultsContainer) {
-      return;
-    }
-
-    // Start by constructing a URI object from the passed-in URL.
-    // If the input was malformed, bail.
-    let recommendationURI;
-    try {
-      recommendationURI = this.io.newURI(recommendationUrl, null, null);
-    } catch (ex) {
-      return;
-    }
-
-    // Grab a non-live NodeList of currently-visible results. Bail if there
-    // are none.
-    const results = this.resultsContainer.querySelectorAll('.autocomplete-richlistitem:not([collapsed])');
-    if (!results.length) {
-      return;
-    }
-
-    // Only check the first page of results, which may be up to six items.
-    let visibleCount = Math.min(results.length, 6);
-
-    for (let i = 0; i < visibleCount; i++) {
-      let resultURI;
-      const resultUrl = results[i].getAttribute('url');
-      // If the result URL is malformed or empty, move on to the next one.
-      try {
-        resultURI = this.io.newURI(resultUrl, null, null);
-      } catch (ex) {
-        continue;
-      }
-
-      // 'moz-action' URLs (switch to tab, or search suggestion) have an empty
-      // string asciiHost. Don't bother trying to compare domains in this case.
-      if (!resultURI.asciiHost) {
-        continue;
-      }
-
-      // The eTLD service should give us a good, cheap guess at the domain.
-      if (this.eTLD.getBaseDomain(resultURI) === this.eTLD.getBaseDomain(recommendationURI)) {
-        return true;
-      }
-    }
   }
 };

--- a/lib/ui/recommendation.js
+++ b/lib/ui/recommendation.js
@@ -15,7 +15,6 @@ function Recommendation(opts) {
   this.io = opts.io;
   this.objectUtils = opts.objectUtils;
   this.RecommendationRow = opts.RecommendationRow;
-  this.popup = opts.popup;
 
   this.el = null;
   this.timeout = null;
@@ -118,16 +117,6 @@ Recommendation.prototype = {
     this.events.publish('recommendation-mousemove', evt);
   },
   show: function(data) {
-    // If one of the results shown on the first page of the popup has the
-    // same base domain as the recommendation, then the recommendation is
-    // considered a duplicate, and we don't show it.
-    if (!this.popup.domainVisible(data.result.url)) {
-      this._show(data);
-    }
-  },
-  _show: function(data) {
-    // Note: clearing this hide timeout is intentionally moved past the
-    // duplicate check in the show() method.
     if (this.timeout) {
       this.win.clearTimeout(this.timeout);
       this.timeout = null;

--- a/lib/universal-search.js
+++ b/lib/universal-search.js
@@ -185,24 +185,15 @@ Search.prototype = {
     });
     app.recommendationServer.init();
 
-    app.popup = new app.Popup({
-      win: win,
-      events: app.events,
-      eTLD: Services.eTLD,
-      io: Services.io
-    });
-    app.popup.init();
-
     // NOTE: order matters here, the urlbar and highlightManager both need
-    // to be handed the initialized recommendation.
+    // to be handed the initialized recommendation
     app.recommendation = new app.Recommendation({
       eTLD: Services.eTLD,
       events: app.events,
       io: Services.io,
       objectUtils: ObjectUtils,
       win: win,
-      RecommendationRow: app.RecommendationRow,
-      popup: app.popup
+      RecommendationRow: app.RecommendationRow
     });
     app.recommendation.init();
 
@@ -213,6 +204,12 @@ Search.prototype = {
       recommendation: app.recommendation
     });
     app.urlbar.init();
+
+    app.popup = new app.Popup({
+      win: win,
+      events: app.events
+    });
+    app.popup.init();
 
     app.highlightManager = new app.HighlightManager({
       win: win,


### PR DESCRIPTION
Reverts mozilla/universal-search#136.

Unfortunately, the duplicate checking code seems to have broken highlight stealing. Reverting, will retry with a different approach.
