### PR TITLE
118 remove initial highlight

### DIFF
--- a/lib/ui/highlight-manager.js
+++ b/lib/ui/highlight-manager.js
@@ -43,6 +43,7 @@ HighlightManager.prototype = {
     this.resultsObserver.disconnect();
     this.detachMouseListeners();
 
+    this.events.unsubscribe('recommendation-created', this.initMutationObserver);
     this.events.unsubscribe('recommendation-shown', this.stealHighlight);
     this.events.unsubscribe('navigational-key', this.adjustHighlight);
 

--- a/lib/ui/highlight-manager.js
+++ b/lib/ui/highlight-manager.js
@@ -17,13 +17,20 @@ function HighlightManager(opts) {
   // class manages passing focus between it and the list of results
   this.recommendation = opts.recommendation;
 
+  // hasInteracted tracks whether the user has moused over the popup, or keyed
+  // through the popup, since the last urlbar input (typed printable keys or
+  // pasted text). If the user has not interacted with the popup, it's safe to
+  // steal the highlight.
+  this.hasInteracted = false;
+
   this.adjustHighlight = this.adjustHighlight.bind(this);
-  this.clearRecommendationHighlight = this.clearRecommendationHighlight.bind(this);
+  this.onResultsListMouseOver = this.onResultsListMouseOver.bind(this);
   this.initMutationObserver = this.initMutationObserver.bind(this);
-  this.mutationHandler = this.mutationHandler.bind(this);
   this.onRecommendationMouseEnter = this.onRecommendationMouseEnter.bind(this);
   this.onRecommendationMouseLeave = this.onRecommendationMouseLeave.bind(this);
   this.onRecommendationMouseMove = this.onRecommendationMouseMove.bind(this);
+  this.resetInteractionState = this.resetInteractionState.bind(this);
+  this.onUrlbarChange = this.onUrlbarChange.bind(this);
   this.stealHighlight = this.stealHighlight.bind(this);
 }
 
@@ -35,6 +42,8 @@ HighlightManager.prototype = {
     // then try a second time to attach the MutationObserver to the element.
     this.events.subscribe('recommendation-created', this.initMutationObserver);
     this.events.subscribe('recommendation-shown', this.stealHighlight);
+    this.events.subscribe('urlbar-change', this.onUrlbarChange);
+    this.events.subscribe('before-popup-hide', this.resetInteractionState);
 
     this.attachMouseListeners();
     this.initMutationObserver();
@@ -46,6 +55,8 @@ HighlightManager.prototype = {
     this.events.unsubscribe('recommendation-created', this.initMutationObserver);
     this.events.unsubscribe('recommendation-shown', this.stealHighlight);
     this.events.unsubscribe('navigational-key', this.adjustHighlight);
+    this.events.unsubscribe('urlbar-change', this.onUrlbarChange);
+    this.events.subscribe('before-popup-hide', this.resetInteractionState);
 
     delete this.popup;
     delete this.recommendation;
@@ -87,21 +98,23 @@ HighlightManager.prototype = {
     // When the user mouses over the results list, the recommendation may have
     // the highlight, and should lose the highlight. This happens if the user
     // mouses directly into the results list from outside the popup.
-    this.events.subscribe('results-list-mouse-highlighted', this.clearRecommendationHighlight);
+    this.events.subscribe('results-list-mouse-highlighted', this.onResultsListMouseOver);
   },
   detachMouseListeners: function() {
     this.events.unsubscribe('recommendation-mouseenter', this.stealHighlight);
     this.events.unsubscribe('recommendation-mouseleave', this.onRecommendationMouseLeave);
     this.events.unsubscribe('recommendation-mousemove', this.onRecommendationMouseMove);
-    this.events.unsubscribe('results-list-mouse-highlighted', this.clearRecommendationHighlight);
+    this.events.unsubscribe('results-list-mouse-highlighted', this.onResultsListMouseOver);
   },
   onRecommendationMouseEnter: function() {
     // See attachMouseListeners() for documentation.
+    this.hasInteracted = true;
     this.popup.el.richlistbox.selectedIndex = -1;
     this.recommendation.isHighlighted = true;
   },
   onRecommendationMouseMove: function() {
     // See attachMouseListeners() for documentation.
+    this.hasInteracted = true;
     this.popup.el.richlistbox.selectedIndex = -1;
     this.recommendation.isHighlighted = true;
   },
@@ -114,6 +127,25 @@ HighlightManager.prototype = {
       this.recommendation.isHighlighted = false;
     }
   },
+  onResultsListMouseOver: function() {
+    // See attachMouseListeners() for documentation.
+    this.hasInteracted = true;
+    this.recommendation.isHighlighted = false;
+  },
+  resetInteractionState: function() {
+    // Because clearHighlight checks the `hasInteracted` state, unset it when
+    // the popup closes, not when it reopens, to avoid races that could lead
+    // to the highlight not being correctly stolen. See also the hasInteracted
+    // docs in the constructor.
+    this.hasInteracted = false;
+  },
+  onUrlbarChange: function() {
+    // When the contents of the urlbar are updated, we need to reset the
+    // interaction state, and re-steal the highlight (new results will be
+    // rendered in response to the urlbar change).
+    this.resetInteractionState();
+    this.stealHighlight();
+  },
   initMutationObserver: function() {
     // Use a MutationObserver to detect when results are inserted into the
     // popup. Unfortunately, while the history and suggestions searches return
@@ -123,7 +155,7 @@ HighlightManager.prototype = {
     // richlistbox. This ensures changes are detected, even when rows are
     // reused, rather than created (see the use of maxRows in _adjustAcItem,
     // inside autocomplete.xml).
-    this.resultsObserver = new this.win.MutationObserver(this.mutationHandler);
+    this.resultsObserver = new this.win.MutationObserver(this.stealHighlight);
     const results = this.win.document.getAnonymousElementByAttribute(this.popup.el, 'anonid', 'richlistbox');
     const resultsObserverConfig = {
       childList: true,
@@ -133,23 +165,17 @@ HighlightManager.prototype = {
     };
     this.resultsObserver.observe(results, resultsObserverConfig);
   },
-  mutationHandler: function() {
-    // If the recommendation exists and is visible, steal the highlight.
-    if (this.recommendation.el && !this.recommendation.el.collapsed) {
-      this.stealHighlight();
-    }
-  },
   stealHighlight: function() {
-    // If the recommendation is shown, the default behavior is for the urlbar
-    // to have the highlight. That is, neither the recommendation nor any items
-    // in the results list should be highlighted.
+    // Current default Firefox behavior is to highlight the top 'heuristic'
+    // result when the popup is first shown. For a given input string foo, the
+    // heuristic result either reads, "Visit foo", if foo looks like a URL,
+    // or it reads, "foo - Search with $searchProvider".
     //
-    // We need to retake control of the highlight under two circumstances:
-    // 1. When the recommendation has just been shown, if the user isn't keying
-    //    through the list already, then move the highlight from the top results
-    //    list item to the urlbar.
-    // 2. After (1), when a few more results have been inserted into the DOM,
-    //    the Gecko code will take the highlight again; steal it back.
+    // We want to remove the highlight from the top result, so that it appears
+    // that the urlbar is focused when the popup first appears.
+    //
+    // The Firefox autocomplete popup implementation makes stealing the
+    // highlight a bit complicated:
     //
     // The existing XBL code batches insertions in timeouts. By default,
     // the code invokes setTimeout 5 times, inserting 6 rows per turn, up
@@ -165,36 +191,38 @@ HighlightManager.prototype = {
     //
     // Specifically, each time stealHighlight is called (in response to a DOM
     // mutation fired when rows are inserted into the list), we ask the browser
-    // to steal the highlight three times: immediately, just before the next
-    // frame is painted (the outer rAF), and just before the frame after that
-    // (the inner rAF).
+    // to steal the highlight six times: immediately, just before the next
+    // frame is painted (the outer rAF), and just before the next four frames
+    // (the inner rAF calls).
     //
     // This is a weird hack, but it works fairly well. Because setTimeout makes
     // no guarantees about precisely when a callback will be executed, and
     // because the row insertion timeouts are called closely together, ours is
     // a pretty good, though nondeterministic, solution.
-    if (!this.recommendation.el || this.recommendation.el.collapsed) {
-      return;
-    }
     this.clearHighlight();
     this.win.requestAnimationFrame(() => {
       this.clearHighlight();
       this.win.requestAnimationFrame(() => {
         this.clearHighlight();
+        this.win.requestAnimationFrame(() => {
+          this.clearHighlight();
+          this.win.requestAnimationFrame(() => {
+            this.clearHighlight();
+            this.win.requestAnimationFrame(() => {
+              this.clearHighlight();
+            });
+          });
+        });
       });
     });
   },
   clearHighlight: function() {
-    // If the selectedIndex > 0, the user is keying through the list, so don't
-    // do anything to the highlight.
-    if (this.popup.el.richlistbox.selectedIndex > 0) {
+    // If the user has interacted with the popup since the last urlbar input,
+    // don't mess with the highlight.
+    if (this.hasInteracted) {
       return;
     }
     this.popup.el.richlistbox.selectedIndex = -1;
-    this.recommendation.isHighlighted = false;
-  },
-  clearRecommendationHighlight: function() {
-    // See attachMouseListeners() for documentation.
     this.recommendation.isHighlighted = false;
   },
   adjustHighlight: function(evt) {
@@ -301,9 +329,8 @@ HighlightManager.prototype = {
     // of the list.
     //
     // It turns out that scrolling the results list (the 'forward' case)
-    // causes the results list to retake the highlight. If the recommendation
-    // is shown, we want to steal the highlight back for the urlbar. (If not,
-    // the top result item will be highlighted, the expected behavior.)
+    // causes the top result in the results list to retake the highlight, so we
+    // steal it back.
     //
     // An additional complication: if the mouse pointer is over the popup when
     // the results list scrolls, a mouseover event will be fired on the result
@@ -312,9 +339,7 @@ HighlightManager.prototype = {
     // to ignore the very next mouseover event it receives.
     } else if (selectedIndex === listLength - 1) {
       if (evt.forward) {
-        if (recommendationVisible) {
-          this.stealHighlight();
-        }
+        this.stealHighlight();
         this.popup.ignoreNextMouseOver = true;
         resultsContainer.ensureIndexIsVisible(0);
         highlightUrlbar();


### PR DESCRIPTION
@chuckharmston R? if you're around, if not I'll land this tomorrow.

Bug #118 asks that we always steal the highlight when the popup is opened or new results are rendered. That's done here, with caveats: highlight stealing doesn't work if only the 'heuristic' top result is shown (#140); highlight stealing fails if the popup opens under the mouse pointer (#143). I'll tackle those issues in followup PRs.

Aside from making the highlighting uniform across recommendation shown and unshown cases, the main improvement here is better highlight stealing! Since we don't need to know if the recommendation is visible before stealing the highlight, it seems that our code wins the race more often. I also added three more nested `requestAnimationFrame` calls (now a total of 6). The final result is really nice: the blue highlight is much harder to summon, at least on my machine.
