### PR TITLE
Adjust XUL popup state, fixing popup in Nightly

### DIFF
--- a/lib/ui/popup.js
+++ b/lib/ui/popup.js
@@ -12,6 +12,7 @@ function Popup(opts) {
   this.win = opts.win;
   this.events = opts.events;
   this.mouseOverTimeout = null;
+  this.popupOpenObserver = null;
 
   // Public property used when we need to ignore a single mouseover event,
   // due to the mouse pointer being positioned over the popup when the results
@@ -20,12 +21,30 @@ function Popup(opts) {
 
   this.beforePopupHide = this.beforePopupHide.bind(this);
   this.onResultsMouseOver = this.onResultsMouseOver.bind(this);
+  this.onFirstPopupOpen = this.onFirstPopupOpen.bind(this);
 }
 
 Popup.prototype = {
   init: function() {
     this.el = this.win.document.getElementById('PopupAutoCompleteRichResult');
     this.el.addEventListener('popuphiding', this.beforePopupHide);
+
+    // The first time the popup opens, a bit of popup state is not set
+    // correctly, causing no results to be shown, and causing the popup to fail
+    // to appear more than once (#138). To work around this bug, listen for the
+    // popup to be opened for the first time, and set the missing state.
+    //
+    // (The changes that introduced this bug are large (~1800 lines) and
+    // complex: https://github.com/mozilla/gecko-dev/commit/ee27759c)
+    //
+    // Listen for the popup's first open by using a MutationObserver to detect
+    // a change in the popup element's 'hidden' attribute.
+    this.popupOpenObserver = new this.win.MutationObserver(this.onFirstPopupOpen);
+    let observerConfig = {
+      attributes: true,
+      attributeFilter: ['hidden']
+    };
+    this.popupOpenObserver.observe(this.el, observerConfig);
   },
   destroy: function() {
     this.el.removeEventListener('popuphiding', this.beforePopupHide);
@@ -35,8 +54,33 @@ Popup.prototype = {
     delete this.el;
     delete this.win;
   },
+  onFirstPopupOpen: function(evt) {
+    // The popup is opening for the first time. Set the missing state so that
+    // it works correctly. See also the docs on the MutationObserver created
+    // in the constructor.
+    this.el.mInput = this.win.gURLBar;
+    // The observer is only needed the first time the popup opens per window,
+    // so get rid of it.
+    this.popupOpenObserver.disconnect();
+    this.popupOpenObserver = null;
+  },
   beforePopupHide: function(evt) {
     this.events.publish('before-popup-hide');
+
+    // Pass the event through to the XBL handler, so that this.mPopupOpen can
+    // be reset to false. Otherwise, the popup won't open correctly (#138).
+    // Unfortunately, we can't hand off the event to the XBL handler: it's
+    // inaccessible from JS (or at least, I don't know how to get a pointer).
+    // Instead, create a synthetic popuphiding event, and fire it on the DOM.
+    let newEvent = new this.win.MouseEvent({
+      type: 'popuphiding'
+    });
+    // Because we are triggering a synthetic popuphiding event from a
+    // popuphiding event listener, momentarily disconnect this listener while
+    // firing the event.
+    this.el.removeEventListener('popuphiding', this.beforePopupHide);
+    this.el.dispatchEvent(newEvent);
+    this.el.addEventListener('popuphiding', this.beforePopupHide);
   },
   onResultsMouseOver: function(evt) {
     if (this.ignoreNextMouseOver) {


### PR DESCRIPTION
Fixes #138.

Commit message below summarizes the situation reasonably well. @chuckharmston, R? if you're around, if not, I'll review, double-check, and land this myself tomorrow.

Commit message follows:

---

First, when the popup opens for the first time, its `mInput` will be
null, which breaks rendering of all the results. To work around this,
detect when the popup opens for the first time, via a MutationObserver
on the popup's 'hidden' attribute, then set the missing `mInput` state.

Second, each time the popup closes, its `mPopupOpen` state needs to be
reset to false. This is normally done by the `popuphiding` listener
defined in XBL. However, because our code defines its own `popuphiding`
listener, it seems that the XBL handler is not called. Work around this
by temporarily detaching our listener, firing a synthetic `popuphiding`
event on the XUL popup element, then reattaching the listener.

Note that I'm not convinced attaching a DOM Level 2 event listener
should ever have the effect of breaking an XBL (pseudo-DOM Level 0)
handler. Treat the explanation in the previous paragraph as a
hypothesis, not as a theorem :-P

Fixes #138.
