### PR TITLE
Detect mouse movement via mousemove, not mouseover

### DIFF
--- a/chrome/content/binding.xml
+++ b/chrome/content/binding.xml
@@ -46,8 +46,8 @@
   ]]>
   <binding id="autocomplete-richlistbox" extends="chrome://global/content/bindings/autocomplete.xml#autocomplete-richlistbox">
     <handlers>
-      <handler event="mouseover" phase="capturing"><![CDATA[
-        window.universalSearch.popup.onResultsMouseOver(event);
+      <handler event="mousemove" phase="capturing"><![CDATA[
+        window.universalSearch.popup.onResultsMouseMove(event);
       ]]></handler>
     </handlers>
   </binding>

--- a/lib/ui/highlight-manager.js
+++ b/lib/ui/highlight-manager.js
@@ -24,7 +24,7 @@ function HighlightManager(opts) {
   this.hasInteracted = false;
 
   this.adjustHighlight = this.adjustHighlight.bind(this);
-  this.onResultsListMouseOver = this.onResultsListMouseOver.bind(this);
+  this.onResultsListMouseMove = this.onResultsListMouseMove.bind(this);
   this.initMutationObserver = this.initMutationObserver.bind(this);
   this.onRecommendationMouseEnter = this.onRecommendationMouseEnter.bind(this);
   this.onRecommendationMouseLeave = this.onRecommendationMouseLeave.bind(this);
@@ -98,13 +98,17 @@ HighlightManager.prototype = {
     // When the user mouses over the results list, the recommendation may have
     // the highlight, and should lose the highlight. This happens if the user
     // mouses directly into the results list from outside the popup.
-    this.events.subscribe('results-list-mouse-highlighted', this.onResultsListMouseOver);
+    //
+    // Additionally, once the mouse moves over the results list, we do not
+    // steal the highlight until the popup contents change, or until the
+    // popup is closed and reopened.
+    this.events.subscribe('results-list-mouse-highlighted', this.onResultsListMouseMove);
   },
   detachMouseListeners: function() {
     this.events.unsubscribe('recommendation-mouseenter', this.stealHighlight);
     this.events.unsubscribe('recommendation-mouseleave', this.onRecommendationMouseLeave);
     this.events.unsubscribe('recommendation-mousemove', this.onRecommendationMouseMove);
-    this.events.unsubscribe('results-list-mouse-highlighted', this.onResultsListMouseOver);
+    this.events.unsubscribe('results-list-mouse-highlighted', this.onResultsListMouseMove);
   },
   onRecommendationMouseEnter: function() {
     // See attachMouseListeners() for documentation.
@@ -127,7 +131,7 @@ HighlightManager.prototype = {
       this.recommendation.isHighlighted = false;
     }
   },
-  onResultsListMouseOver: function() {
+  onResultsListMouseMove: function() {
     // See attachMouseListeners() for documentation.
     this.hasInteracted = true;
     this.recommendation.isHighlighted = false;
@@ -332,15 +336,9 @@ HighlightManager.prototype = {
     // causes the top result in the results list to retake the highlight, so we
     // steal it back.
     //
-    // An additional complication: if the mouse pointer is over the popup when
-    // the results list scrolls, a mouseover event will be fired on the result
-    // that's scrolled underneath the mouse pointer. We want to ignore this
-    // event, whether or not the recommendation is visible, so ask the popup
-    // to ignore the very next mouseover event it receives.
     } else if (selectedIndex === listLength - 1) {
       if (evt.forward) {
         this.stealHighlight();
-        this.popup.ignoreNextMouseOver = true;
         resultsContainer.ensureIndexIsVisible(0);
         highlightUrlbar();
       } else {

--- a/lib/ui/popup.js
+++ b/lib/ui/popup.js
@@ -11,16 +11,11 @@ function Popup(opts) {
   */
   this.win = opts.win;
   this.events = opts.events;
-  this.mouseOverTimeout = null;
+  this.mouseMoveTimeout = null;
   this.popupOpenObserver = null;
 
-  // Public property used when we need to ignore a single mouseover event,
-  // due to the mouse pointer being positioned over the popup when the results
-  // list scrolls itself. See HighlightManager for more.
-  this.ignoreNextMouseOver = false;
-
   this.beforePopupHide = this.beforePopupHide.bind(this);
-  this.onResultsMouseOver = this.onResultsMouseOver.bind(this);
+  this.onResultsMouseMove = this.onResultsMouseMove.bind(this);
   this.onFirstPopupOpen = this.onFirstPopupOpen.bind(this);
 }
 
@@ -49,7 +44,7 @@ Popup.prototype = {
   destroy: function() {
     this.el.removeEventListener('popuphiding', this.beforePopupHide);
 
-    this.win.clearTimeout(this.mouseOverTimeout);
+    this.win.clearTimeout(this.mouseMoveTimeout);
 
     delete this.el;
     delete this.win;
@@ -82,20 +77,15 @@ Popup.prototype = {
     this.el.dispatchEvent(newEvent);
     this.el.addEventListener('popuphiding', this.beforePopupHide);
   },
-  onResultsMouseOver: function(evt) {
-    if (this.ignoreNextMouseOver) {
-      this.ignoreNextMouseOver = false;
+  onResultsMouseMove: function(evt) {
+    // Throttle mousemove events, which fire rapidly as the user moves
+    // the mouse.
+    if (this.mouseMoveTimeout) {
       return;
     }
-
-    // Throttle mouseover events, which fire rapidly if the user quickly moves
-    // the mouse across different DOM elements in the results list.
-    if (this.mouseOverTimeout) {
-      return;
-    }
-    this.mouseOverTimeout = this.win.setTimeout(() => {
-      this.win.clearTimeout(this.mouseOverTimeout);
-      this.mouseOverTimeout = null;
+    this.mouseMoveTimeout = this.win.setTimeout(() => {
+      this.win.clearTimeout(this.mouseMoveTimeout);
+      this.mouseMoveTimeout = null;
     }, 15);
 
     this.events.publish('results-list-mouse-highlighted');


### PR DESCRIPTION
@chuckharmston R? I've tried to thoroughly document the changes here. Please let me know if anything seems unclear.

Verifying this PR works: position the mouse pointer so that, when you type in the urlbar, the popup opens under the pointer. Without this PR applied, highlight stealing will break due to spurious mouseover events, causing the top result to take the blue highlight. With this PR applied, highlight stealing should work.

Original commit message follows:

---

Effective highlight stealing requires adjusting the highlight over many
(currently 6) successive turns for each DOM Mutation observed as results
stream into the popup. Because the stealing spans 6 \* 17ms ~= 100ms, we
need to detect when the mouse is moving and stop stealing the highlight
immediately. We used to do this by listening for mouseover events on the
popup, then canceling further highlight stealing until the popup
contents were updated.

When the popup opens under the mouse pointer, one or more spurious
mouseover events are fired. This makes highlight stealing buggy: we can
ignore a single mouseover event, but there's no easy way to know how
many mouseovers will be fired when the DOM is updated with new results.

In contrast, mousemove events are not spuriously fired when the popup is
opened under the mouse pointer. Mousemove events fire even more often
than mouseover events, so they are still a great tool to detect when the
user is actively mousing through the popup (the case where we want to
abort highlight stealing, even if results are still streaming in).
- Rename mouseover listener / variable names to mousemove.
- Remove the 'ignoreNextMouseOver' state on the popup; it's not needed,
  now that we are using mousemove.
- Update code docs.

Fixes #143.
