### PR TITLE
Release docs

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -95,11 +95,13 @@ Updated: https://s3-us-west-2.amazonaws.com/universal-search/universal-search.xp
 
 To release a new version of the add-on:
 
-1. Increment the version numbers in `update.rdf` and `install.rdf`. It must be higher than the previous verions.
-2. Run `make`.
-3. Verify that the add-on was correctly uploaded by downloading the URL demonstrated by the output, e.g.
+1. Increment the version numbers in `update.rdf` and `install.rdf`. The new version number must be higher than the previous versions.
+2. `git commit` the rdf file changes, with a commit message of the form "Version a.b.c".
+3. Run `make`.
+4. Verify that the add-on was correctly uploaded by downloading the URL demonstrated by the output, e.g.
 
-```shell
-$ curl -I https://s3-us-west-2.amazonaws.com/universal-search/universal-search-1.0.0.xpi
-HTTP/1.1 200 OK
-```
+  ```shell
+  $ curl -I https://s3-us-west-2.amazonaws.com/universal-search/universal-search-1.0.0.xpi
+  HTTP/1.1 200 OK
+  ```
+5. Push the new commit, and the newly-created git tag, to the main Mozilla repo.

--- a/install.rdf
+++ b/install.rdf
@@ -5,7 +5,7 @@
     <em:bootstrap>true</em:bootstrap>
     <em:type>2</em:type>
     <em:unpack>false</em:unpack>
-    <em:version>1.0.0b2</em:version>
+    <em:version>1.0.1</em:version>
     <em:name>Universal Search</em:name>
     <em:description>Universal Search desktop FF experiments in addon format</em:description>
     <em:creator/>

--- a/update.rdf
+++ b/update.rdf
@@ -6,7 +6,7 @@
       <RDF:Seq>
         <RDF:li>
           <RDF:Description>
-            <em:version>1.0.0b2</em:version>
+            <em:version>1.0.1</em:version>
             <em:targetApplication>
               <RDF:Description>
                 <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>


### PR DESCRIPTION
@chuckharmston R?

Bump version to 1.0.1 and make the release docs more verbose.

Nicely formatted release docs: https://github.com/6a68/universal-search/blob/release-docs/docs/building.md
