### PR TITLE
Don't send cookies when making server requests

### DIFF
--- a/lib/recommendation-server.js
+++ b/lib/recommendation-server.js
@@ -4,6 +4,8 @@
 
 const EXPORTED_SYMBOLS = ['RecommendationServer']; // eslint-disable-line no-unused-vars
 
+const Ci = Components.interfaces;
+
 function RecommendationServer(opts) {
   /*
   Class providing a connection to a recommendation server and a method for
@@ -23,7 +25,7 @@ function RecommendationServer(opts) {
   */
   this.events = opts.events;
   this.timeout = opts.timeout;
-  // note: xhr service, not xhr instance
+  // Note: this is the xhr service, not an xhr instance
   this.xhr = opts.xhr;
   this.console = opts.console;
   this.prefs = opts.prefs;
@@ -74,6 +76,8 @@ RecommendationServer.prototype = {
         req.isInFlight = false;
       });
       req.open('GET', `${this.server}/__lbheartbeat__`);
+      // Do not send cookies with requests, to prevent user tracking. (#148)
+      req.channel.loadFlags = Ci.nsIChannel.LOAD_ANONYMOUS;
       req.isInFlight = true;
       req.send();
     }
@@ -132,6 +136,8 @@ RecommendationServer.prototype = {
           reject(`No recommendation available for "${query}".`);
         });
         req.open('GET', endpoint);
+        // Do not send cookies with requests, to prevent user tracking. (#148)
+        req.channel.loadFlags = Ci.nsIChannel.LOAD_ANONYMOUS;
         req.isInFlight = true;
         req.send();
       } catch (err) {


### PR DESCRIPTION
@chuckharmston Mind taking a look? Security folks asked that we not send cookies when making requests from the recommendation server. Took a little digging, but it turns out that Gecko provides some non-standard flags with xhr, one of which strips cookies from the request: https://dxr.mozilla.org/mozilla-central/source/netwerk/base/nsIRequest.idl#205-210

This PR adds those flags in the spots where we make requests. You can verify the cookies are not being sent in the Network tab of the Browser Toolbox.

Fixes #148.
