### PR TITLE
Unescape HTML entities shown as text

### DIFF
--- a/lib/ui/recommendation-row.js
+++ b/lib/ui/recommendation-row.js
@@ -151,7 +151,7 @@ RecommendationRow.prototype = {
     recommendation's title.
     */
     let elem = createElement(row.doc, 'description', 'title');
-    elem.textContent = row._get('result.title');
+    elem.textContent = row._unescape(row._get('result.title'));
     return elem;
   },
 
@@ -161,7 +161,7 @@ RecommendationRow.prototype = {
     recommendation's URL.
     */
     let elem = createElement(row.doc, 'description', 'url');
-    elem.textContent = row._get('result.url');
+    elem.textContent = row._unescape(row._get('result.url'));
     elem.setAttribute('data-url', row._get('result.url'));
     return elem;
   },
@@ -266,6 +266,14 @@ RecommendationRow.prototype = {
       row.doc.getElementById('PopupAutoCompleteRichResult').width);
     const available = popupWidth - MAGIC;
     return available >= MIN ? available : MIN;
+  },
+
+  _unescape: function(txt) {
+    /*
+    Uses the DOMParser to safely unescape HTML entities.
+    */
+    let doc = new this.win.DOMParser().parseFromString(txt, 'text/html');
+    return doc.documentElement.textContent;
   }
 };
 


### PR DESCRIPTION
@chuckharmston R?

This PR unescapes any HTML entities sent over the wire.

Easy to verify by typing "a " (note the space) in the urlbar. This seems to return the "A&E" TV network, at least for my local instance, and you can verify that it doesn't look like `A&amp;E`:

<img width="463" alt="screen shot 2016-04-29 at 4 58 28 pm" src="https://cloud.githubusercontent.com/assets/96396/14932501/1d3d0790-0e2c-11e6-9fbc-f7716e9b2f11.png">

Fixes #155.
