### PR TITLE
Load images using Fetch, to avoid sending cookies to third parties

### DIFF
--- a/lib/ui/recommendation-row.js
+++ b/lib/ui/recommendation-row.js
@@ -52,10 +52,23 @@ RecommendationRow.prototype = {
     let favicon = row._get('enhancements.favicon.url');
     let defaultFavicon = 'chrome://mozapps/skin/places/defaultFavicon@2x.png';
     let elem = createElement(row.doc, 'image', 'favicon');
-    elem.setAttribute('src', favicon ? favicon : defaultFavicon);
-    elem.onerror = function(evt) {
+
+    if (!favicon) {
       elem.setAttribute('src', defaultFavicon);
     }
+
+    row.win.fetch(favicon, {
+      mode: 'no-cors'
+    }).then((response) => {
+      response.blob().then(imgBlob => {
+        let imgUrl = row.win.URL.createObjectURL(imgBlob);
+        elem.setAttribute('src', imgUrl);
+      });
+    }, (err) => {
+      elem.setAttribute('src', defaultFavicon);
+    });
+
+    // Note that we return the element before its 'src' is set.
     return elem;
   },
 
@@ -86,10 +99,20 @@ RecommendationRow.prototype = {
     place.
     */
     let elem = createElement(row.doc, 'image', 'logo');
-    elem.setAttribute('src', `${logoUrl}?size=${IMAGE_DIMENSION * 2}`);
-    elem.onerror = function() {
+    let clearbitUrl = `${logoUrl}?size=${IMAGE_DIMENSION * 2}`;
+
+    row.win.fetch(clearbitUrl, {
+      mode: 'no-cors'
+    }).then((response) => {
+      response.blob().then(imgBlob => {
+        let logoImageUrl = row.win.URL.createObjectURL(imgBlob);
+        elem.setAttribute('src', logoImageUrl);
+      });
+    }, (err) => {
       elem.parentNode.replaceChild(row.renderLetterbox(row), elem);
-    }
+    });
+
+    // Note that we return the element before its 'src' is set.
     return elem;
   },
 
@@ -102,14 +125,24 @@ RecommendationRow.prototype = {
     */
     let elem = createElement(row.doc, 'image', 'keyimage');
     let sizes = row._getKeyImageSizes(keyImage);
-    elem.setAttribute('src', keyImage.url);
+
     elem.setAttribute('height', sizes.height);
     elem.style.height = `${sizes.height}px`;
     elem.setAttribute('width', sizes.width);
     elem.style.width = `${sizes.width}px`;
-    elem.onerror = function() {
+
+    row.win.fetch(keyImage.url, {
+      mode: 'no-cors'
+    }).then((response) => {
+      response.blob().then(imgBlob => {
+        let keyImageUrl = row.win.URL.createObjectURL(imgBlob);
+        elem.setAttribute('src', keyImageUrl);
+      });
+    }, (err) => {
       elem.parentNode.replaceChild(row.renderLetterbox(row), elem);
-    }
+    });
+
+    // Note that we return the element before its 'src' is set.
     return elem;
   },
 


### PR DESCRIPTION
@chuckharmston R?

Use Fetch to avoid leaking cookies when loading images. Code largely lifted from https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch.

Fixes #150.
