### PR TITLE
Duplicate check

### DIFF
--- a/lib/ui/recommendation.js
+++ b/lib/ui/recommendation.js
@@ -4,6 +4,10 @@
 
 const EXPORTED_SYMBOLS = ['Recommendation'];
 const RECOMMENDATION_ID = 'universal-search-recommendation';
+// borrowed from urlbarBindings.xml, _parseActionUrl method
+const MOZ_ACTION_REGEX = /^moz-action:([^,]+),(.*)$/;
+
+const Ci = Components.interfaces;
 
 function Recommendation(opts) {
   /*
@@ -21,6 +25,11 @@ function Recommendation(opts) {
   this.mouseMoveTimeout = null;
   this.prev = null;
   this.row = null;
+  this.searchResults = null;
+  // this.recData is used for duplicate checking, but sort of overlaps with
+  // this.prev / this.data. Consider just storing the data in one place.
+  this.recData = null;
+  this.searchController = null;
 
   Object.defineProperty(this, 'isHighlighted', {
     get: () => {
@@ -40,8 +49,11 @@ function Recommendation(opts) {
 
   this.navigate = this.navigate.bind(this);
   this.show = this.show.bind(this);
+  this.onData = this.onData.bind(this);
   this.hide = this.hide.bind(this);
   this._pollForElement = this._pollForElement.bind(this);
+  this.pollController = this.pollController.bind(this);
+  this._controllerCheck = this._controllerCheck.bind(this);
   this.onMouseEnter = this.onMouseEnter.bind(this);
   this.onMouseMove = this.onMouseMove.bind(this);
   this.onMouseLeave = this.onMouseLeave.bind(this);
@@ -59,15 +71,33 @@ Recommendation.prototype = {
       this.events.publish('recommendation-created');
     });
 
-    this.events.subscribe('recommendation', this.show);
-    this.events.subscribe('enter-key', this.navigate);
+    // When the server returns recommendation data, store it, then
+    // optimistically trigger the duplicate check.
+    this.events.subscribe('recommendation', this.onData);
+
+    // When the urlbar changes, poll the C++ controller for results, then
+    // optimistically trigger the duplicate check.
+    this.events.subscribe('urlbar-change', this.pollController);
+
+    // When the urlbar changes, the recommendation becomes stale, so hide it.
     this.events.subscribe('urlbar-change', this.hide);
+
+    // When the popup is about to close, hide the recommendation.
     this.events.subscribe('before-popup-hide', this.hide);
+
+    this.searchController = Components.classes["@mozilla.org/autocomplete/controller;1"].
+                getService(Components.interfaces.nsIAutoCompleteController);
   },
   attachListeners: function() {
+    // When the recommendation is clicked, set some state in the urlbar, then
+    // trigger a navigation.
     this.el.addEventListener('click', this.navigate);
-    this.el.addEventListener('mouseenter', this.onMouseEnter);
+
+    // Relay mouseenter, mouseleave, and mousemove events to the
+    // HighlightManager, so it can adjust the location of the highlight.
+    // Note that mousemove events are throttled to fire at most every 30 ms.
     this.el.addEventListener('mousemove', this.onMouseMove);
+    this.el.addEventListener('mouseenter', this.onMouseEnter);
     this.el.addEventListener('mouseleave', this.onMouseLeave);
   },
   detachListeners: function() {
@@ -84,12 +114,13 @@ Recommendation.prototype = {
   destroy: function() {
     this.detachListeners();
     this.events.unsubscribe('recommendation', this.show);
-    this.events.unsubscribe('enter-key', this.navigate);
     this.events.unsubscribe('urlbar-change', this.hide);
+    this.events.unsubscribe('urlbar-change', this.pollController);
     this.events.unsubscribe('before-popup-hide', this.hide);
 
     this.win.clearTimeout(this.mouseMoveTimeout);
 
+    delete this.searchController;
     delete this.el;
     delete this.win;
   },
@@ -168,6 +199,8 @@ Recommendation.prototype = {
         this.el.collapsed = true;
       }.bind(this), 100);
       this.data = null;
+      this.searchResults = null;
+      this.recData = null;
     }
   },
   navigate: function(evt) {
@@ -187,5 +220,151 @@ Recommendation.prototype = {
     this.win.setTimeout(() => {
       this.events.publish('recommendation-navigate');
     });
+  },
+  onData: function(data) {
+    this.recData = data;
+
+    this.duplicateCheck();
+  },
+  pollController: function() {
+    if (this.isPollingController) {
+      return;
+    }
+    this.isPollingController = true;
+
+    this._controllerCheck();
+  },
+  _controllerCheck: function() {
+    if (this.searchController.searchStatus == Ci.nsIAutoCompleteController.STATUS_COMPLETE_MATCH) {
+      this.isPollingController = false;
+
+      // We only care about duplicates on the first page of results.
+      // Current max is 10 per page across all channels of Firefox.
+      let firstPage = 10;
+      let results = [];
+      for (let i = 0; i < firstPage; i++) {
+        let value = this.searchController.getValueAt(i);
+        if (value) {
+          results.push(value);
+        }
+      }
+      this.searchResults = results;
+
+      this.duplicateCheck();
+    } else if (this.searchController.searchStatus == Ci.nsIAutoCompleteController.STATUS_COMPLETE_NO_MATCH ||
+               this.searchController.searchStatus == Ci.nsIAutoCompleteController.STATUS_NONE) {
+      this.isPollingController = false;
+    } else { /* this.searchController.searchStatus == Ci.nsIAutoCompleteController.STATUS_SEARCHING */
+      this.win.setTimeout(() => { this._controllerCheck() });
+    }
+  },
+  duplicateCheck: function() {
+    // Given recommendation and results data, check if the recommendation
+    // duplicates one of the results, using nsIURI as a quick, easy way to
+    // normalize and compare URLs.
+    //
+    // Comparison rules:
+    // a wikipedia recommendation is a duplicate if a result has the same URL;
+    // a top-level domain recommendation is a duplicate if any result is a page
+    // from that domain (we only want to show new domains).
+
+    if (!this.searchResults || !this.recData) {
+      return;
+    }
+
+    let isDuplicate = false;
+    let type = 'tld' in this.recData.enhancements ? 'tld' : 'wikipedia';
+
+    let recommendationUri;
+    try {
+      // newURI throws if the recommendation URL is malformed.
+      recommendationUri = this.io.newURI(this.recData.result.url, null, null);
+    } catch (ex) {
+      return;
+    }
+
+    for (let i = 0; i < this.searchResults.length; i++) {
+      let result = this.searchResults[i];
+      let resultUri;
+
+      // Sometimes the top heuristic result will just be a bare domain, lacking
+      // the scheme ("http" or "https") and '://' part. The nsIURI constructor
+      // will throw without the scheme, so we must prepend either 'http://' or
+      // 'https://'. Wikipedia uses https, and we do exact matching on
+      // wikipedia recommendations when checking for duplicates, while for TLD
+      // recommendations, we compare base domains, ignoring the scheme.
+      // Therefore, we prepend 'https://' if `result` lacks a scheme.
+      //
+      // It's important to look at the start of the result URL because
+      // moz-action URLs contain a URL, but not at the start of the string,
+      // and our moz-action handling code (further down) would be broken if
+      // 'https://' were prepended.
+      if (result.indexOf('http') !== 0) {
+        result = 'https://' + result;
+      }
+
+      try {
+        resultUri = this.io.newURI(result, null, null);
+      } catch (ex) {
+        continue;
+      }
+
+      // If the result is a moz-action URL, we might need to either replace
+      // the resultUri, if the moz-action contains a URL inside it; or bail
+      // on the current result, if the moz-action doesn't contain a URL.
+      if (this._isMozAction(resultUri)) {
+        resultUri = this._replaceMozAction(resultUri);
+        if (!resultUri) {
+          continue;
+        }
+      }
+
+      // Finally, check for duplicates.
+      // For TLD results, the eTLD service should give us a good, cheap guess
+      // at the domain.
+      // For wikipedia results, use nsIURI.equals() to check for URL equality.
+      // If a duplicate is found, immediately exit.
+      if (type === 'tld' && this.eTLD.getBaseDomain(resultUri) === this.eTLD.getBaseDomain(recommendationUri) ||
+          type === 'wikipedia' && resultUri.equals(recommendationUri)) {
+        return;
+      }
+    }
+
+    this.show(this.recData);
+  },
+  _isMozAction: function(/* nsIURI */ uri) {
+    return MOZ_ACTION_REGEX.test(uri.asciiSpec);
+  },
+  _replaceMozAction: function(/* nsIURI */ result) {
+    // To avoid showing duplicates in the case of special moz-action URLs,
+    // convert those that contain URLs (switchtab, remotetab, or visiturl)
+    // to plain URLs for comparison.
+    //
+    // Returns a falsy value if the moz-action lacks URLs (searchengine,
+    // keyword), or if exceptions are thrown when trying to parse the URL
+    // or convert it into an nsIURI object.
+    //
+    // Example moz-action result:
+    // moz-action:switchtab,{"url":"https%3A%2F%2Fwww.youtube.com%2F"}
+
+    let [, mozActionType, mozActionResult] = result.asciiSpec.match(MOZ_ACTION_REGEX);
+    let wrappedUrl;
+    let newResult;
+
+    if (['switchtab', 'remotetab', 'visiturl'].indexOf(mozActionType) > -1) {
+      try {
+        wrappedUrl = JSON.parse(mozActionResult);
+      } catch(ex) {
+        return;
+      }
+
+      let unescapedUrl = this.win.unescape(wrappedUrl.url);
+
+      try {
+        newResult = this.io.newURI(unescapedUrl, null, null);
+      } catch (ex) {}
+    }
+
+    return newResult;
   }
 };


### PR DESCRIPTION
@chuckharmston Debugged, fully working, and updated.

We are now waiting on two async things: the C++ controller polling code, which tells us what result URLs are about to hit the popup; and the recommendation xhr code, which tells us what the recommendation URL will be. We can't use promises to synchronize the two, because promises always wait a turn to resolve/reject, and the state of the world might change during that time.

Instead, we set a bit of JS state when the recommendation arrives, and when the C++ controller says it's done; a third function, `duplicateCheck`, is called in both cases, so that we run the check as soon as both pieces of data are available.

The duplicate check compares the URLs via the Gecko `nsIURI` object, which does some nice normalization and canonicalization for us.
