### PR TITLE
Use 'popuphidden' instead of 'popuphiding' to detect XUL popup state

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -37,14 +37,14 @@ Metrics.prototype = {
     this.events.subscribe('urlbar-change', this.interactionStart);
 
     // The interaction ends when the popup closes.
-    this.events.subscribe('before-popup-hide', this.interactionEnd);
+    this.events.subscribe('after-popup-hide', this.interactionEnd);
   },
   destroy: function() {
     this.events.unsubscribe('before-popup-show', this.interactionStart);
     this.events.unsubscribe('before-keyboard-navigate', this.onKeyNavigate);
     this.events.unsubscribe('before-click-navigate', this.onClickNavigate);
     this.events.unsubscribe('urlbar-change', this.interactionStart);
-    this.events.unsubscribe('before-popup-hide', this.interactionEnd);
+    this.events.unsubscribe('after-popup-hide', this.interactionEnd);
   },
   interactionStart: function() {
     // Initialize default values for the case where the popup closes without a

--- a/lib/ui/highlight-manager.js
+++ b/lib/ui/highlight-manager.js
@@ -43,7 +43,7 @@ HighlightManager.prototype = {
     this.events.subscribe('recommendation-created', this.initMutationObserver);
     this.events.subscribe('recommendation-shown', this.stealHighlight);
     this.events.subscribe('urlbar-change', this.onUrlbarChange);
-    this.events.subscribe('before-popup-hide', this.resetInteractionState);
+    this.events.subscribe('after-popup-hide', this.resetInteractionState);
 
     this.attachMouseListeners();
     this.initMutationObserver();
@@ -56,7 +56,7 @@ HighlightManager.prototype = {
     this.events.unsubscribe('recommendation-shown', this.stealHighlight);
     this.events.unsubscribe('navigational-key', this.adjustHighlight);
     this.events.unsubscribe('urlbar-change', this.onUrlbarChange);
-    this.events.subscribe('before-popup-hide', this.resetInteractionState);
+    this.events.subscribe('after-popup-hide', this.resetInteractionState);
 
     delete this.popup;
     delete this.recommendation;

--- a/lib/ui/popup.js
+++ b/lib/ui/popup.js
@@ -14,7 +14,7 @@ function Popup(opts) {
   this.mouseMoveTimeout = null;
   this.popupOpenObserver = null;
 
-  this.beforePopupHide = this.beforePopupHide.bind(this);
+  this.afterPopupHide = this.afterPopupHide.bind(this);
   this.beforePopupShow = this.beforePopupShow.bind(this);
   this.onResultsMouseMove = this.onResultsMouseMove.bind(this);
   this.onFirstPopupOpen = this.onFirstPopupOpen.bind(this);
@@ -24,7 +24,7 @@ function Popup(opts) {
 Popup.prototype = {
   init: function() {
     this.el = this.win.document.getElementById('PopupAutoCompleteRichResult');
-    this.el.addEventListener('popuphiding', this.beforePopupHide);
+    this.el.addEventListener('popuphidden', this.afterPopupHide);
     this.el.addEventListener('popupshowing', this.beforePopupShow);
     this.el.addEventListener('click', this.onClick);
 
@@ -46,7 +46,7 @@ Popup.prototype = {
     this.popupOpenObserver.observe(this.el, observerConfig);
   },
   destroy: function() {
-    this.el.removeEventListener('popuphiding', this.beforePopupHide);
+    this.el.removeEventListener('popuphidden', this.afterPopupHide);
     this.el.removeEventListener('popupshowing', this.beforePopupShow);
     this.el.removeEventListener('click', this.onClick);
 
@@ -65,23 +65,8 @@ Popup.prototype = {
     this.popupOpenObserver.disconnect();
     this.popupOpenObserver = null;
   },
-  beforePopupHide: function(evt) {
-    this.events.publish('before-popup-hide');
-
-    // Pass the event through to the XBL handler, so that this.mPopupOpen can
-    // be reset to false. Otherwise, the popup won't open correctly (#138).
-    // Unfortunately, we can't hand off the event to the XBL handler: it's
-    // inaccessible from JS (or at least, I don't know how to get a pointer).
-    // Instead, create a synthetic popuphiding event, and fire it on the DOM.
-    let newEvent = new this.win.MouseEvent({
-      type: 'popuphiding'
-    });
-    // Because we are triggering a synthetic popuphiding event from a
-    // popuphiding event listener, momentarily disconnect this listener while
-    // firing the event.
-    this.el.removeEventListener('popuphiding', this.beforePopupHide);
-    this.el.dispatchEvent(newEvent);
-    this.el.addEventListener('popuphiding', this.beforePopupHide);
+  afterPopupHide: function(evt) {
+    this.events.publish('after-popup-hide');
   },
   beforePopupShow: function(evt) {
     this.events.publish('before-popup-show');

--- a/lib/ui/recommendation.js
+++ b/lib/ui/recommendation.js
@@ -83,7 +83,7 @@ Recommendation.prototype = {
     this.events.subscribe('urlbar-change', this.hide);
 
     // When the popup is about to close, hide the recommendation.
-    this.events.subscribe('before-popup-hide', this.hide);
+    this.events.subscribe('after-popup-hide', this.hide);
 
     this.searchController = Components.classes["@mozilla.org/autocomplete/controller;1"].
                 getService(Components.interfaces.nsIAutoCompleteController);
@@ -116,7 +116,7 @@ Recommendation.prototype = {
     this.events.unsubscribe('recommendation', this.show);
     this.events.unsubscribe('urlbar-change', this.hide);
     this.events.unsubscribe('urlbar-change', this.pollController);
-    this.events.unsubscribe('before-popup-hide', this.hide);
+    this.events.unsubscribe('after-popup-hide', this.hide);
 
     this.win.clearTimeout(this.mouseMoveTimeout);
 


### PR DESCRIPTION
It turns out[1] that DOM Level 2 `addEventListener` handlers, when added
using JS, override XBL handlers for the same events. Nothing seems to
listen for the 'popuphidden' event that's fired just after
'popuphiding', and for our purposes (starting a metrics interaction
event, hiding the recommendation, resetting interaction state in the
highlight manager), either event works fine.

Update the pubsub event from 'before-popup-hide' to 'after-popup-hide',
so that our event names reflect the browser's reality as closely as
possible.

Fixes #164, closes #187.

[1] http://mb.eschew.org/15#sub_15.2.7.1
