### PR TITLE
200 movie card

### DIFF
--- a/chrome/skin/style.css
+++ b/chrome/skin/style.css
@@ -58,15 +58,9 @@ popupset#mainPopupSet panel#PopupAutoCompleteRichResult richlistbox {
   width: 32px;
 }
 
-#universal-search-recommendation-logo,
 #universal-search-recommendation-keyimage {
   position: relative;
   z-index: -1;
-}
-
-#universal-search-recommendation-logo {
-  height: 32px;
-  width: 32px;
 }
 
 #universal-search-recommendation-letterbox {
@@ -174,7 +168,6 @@ popupset#mainPopupSet panel#PopupAutoCompleteRichResult richlistbox {
   background-color: #FFF;
   box-shadow: 0;
 }
-#universal-search-recommendation.highlight #universal-search-recommendation-logo,
 #universal-search-recommendation.highlight #universal-search-recommendation-keyimage {
   z-index: 1;
 }

--- a/chrome/skin/style.css
+++ b/chrome/skin/style.css
@@ -37,7 +37,7 @@ popupset#mainPopupSet panel#PopupAutoCompleteRichResult richlistbox {
 
 #universal-search-recommendation-container {
   display: flex;
-  width: 100%;
+  flex: 1;
 }
 
 #universal-search-recommendation-favicon {
@@ -61,6 +61,11 @@ popupset#mainPopupSet panel#PopupAutoCompleteRichResult richlistbox {
 #universal-search-recommendation-keyimage {
   position: relative;
   z-index: -1;
+}
+
+#universal-search-recommendation-top-content {
+  -moz-box-flex: 1;
+  -moz-box-pack: justify;
 }
 
 #universal-search-recommendation-letterbox {
@@ -108,14 +113,27 @@ popupset#mainPopupSet panel#PopupAutoCompleteRichResult richlistbox {
 #universal-search-recommendation-content {
   flex-grow: 1;
   min-width: 0;
+  -moz-box-align: stretch;
+}
+
+#universal-search-recommendation-details {
+  color: GrayText;
+  -moz-box-align: start;
+  text-overflow: ellipsis;
+  width:100%;
+}
+
+#universal-search-recommendation-description {
+  color: -moz-FieldText;
+  color: FieldText;
+  -moz-box-align: start;
+  text-overflow: ellipsis;
 }
 
 #universal-search-recommendation-title,
 #universal-search-recommendation-url {
   color: -moz-FieldText;
   color: FieldText;
-  display: block;
-  margin: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -133,11 +151,8 @@ popupset#mainPopupSet panel#PopupAutoCompleteRichResult richlistbox {
 }
 
 #universal-search-recommendation-label {
-  color: #BBB;
+  color: GrayText;
   cursor: default;
-  flex-grow: 1;
-  margin-left: 8px;
-  text-align: right;
   -moz-user-select: none;
   user-select: none;
 }
@@ -157,10 +172,12 @@ popupset#mainPopupSet panel#PopupAutoCompleteRichResult richlistbox {
   opacity: 0;
 }
 #universal-search-recommendation.highlight #universal-search-recommendation-title,
-#universal-search-recommendation.highlight #universal-search-recommendation-url {
+#universal-search-recommendation.highlight #universal-search-recommendation-url,
+#universal-search-recommendation.highlight #universal-search-recommendation-description {
   color: HighlightText;
 }
-#universal-search-recommendation.highlight #universal-search-recommendation-label {
+#universal-search-recommendation.highlight #universal-search-recommendation-label,
+#universal-search-recommendation.highlight #universal-search-recommendation-details {
   color: HighlightText;
   opacity: 0.67;
 }

--- a/lib/movie-transform.js
+++ b/lib/movie-transform.js
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const EXPORTED_SYMBOLS = ['movieTransform'];
+
+function MovieTransform() {
+  /*
+  Class that normalizes movie API responses into a data object containing all
+  required keys. Used by the Recommendation to generate a uniform data object
+  to pass into the RecommendationRow for rendering into the XUL DOM.
+
+  This class is stateless, so a singleton instance is created and exported.
+  */
+}
+
+MovieTransform.prototype = {
+  transform: function(data) {
+    if (!this.isValid(data)) {
+      return;
+    }
+    // NOTE: using the full keys repeatedly to aid grepping.
+    const result = {
+      type: 'movie',
+      title: `${data.enhancements.movie.title} (${data.enhancements.movie.year})`,
+      url: data.enhancements.movie.imdb_url,
+      favicon: {
+        url: data.enhancements.favicon.url,
+        color: data.enhancements.favicon.color
+      },
+      // The movie poster's dimensions are missing (recommendation-server
+      // issue #144). For now, the IMDB ratio seems to be 3:2, so just roll with that.
+      keyImage: {
+        url: data.enhancements.movie.poster,
+        height: 96,
+        width: 64
+      },
+      details: this.generateDetails(data),
+      description: data.enhancements.movie.plot
+    };
+    return result;
+  },
+  generateDetails: function(data) {
+    let items = [
+      'IMDB Rating ' + data.enhancements.movie.rating.imdb.raw,
+      data.enhancements.movie.runtime,
+      data.enhancements.movie.genre];
+    return items.join(' - ');
+  },
+  isValid: function(data) {
+    let valid = false;
+    // Just try to access every required key. If one is missing, the thrown Error
+    // will tell us it's an invalid data object. For optional keys, just check
+    // that the parent key exists (if no other check touches the parent).
+    try {
+      valid = data.enhancements.movie.title &&
+              data.enhancements.movie.imdb_url &&
+              data.enhancements.favicon.url &&
+              data.enhancements.favicon.color &&
+              data.enhancements.movie.poster &&
+              data.enhancements.movie.rating.imdb &&
+              data.enhancements.movie.runtime &&
+              data.enhancements.movie.genre;
+    } catch (ex) {}
+    return valid;
+  }
+};
+
+const movieTransform = new MovieTransform();

--- a/lib/tld-transform.js
+++ b/lib/tld-transform.js
@@ -21,6 +21,7 @@ TLDTransform.prototype = {
     if (!this.isValid(data)) {
       return;
     }
+    // NOTE: using the full keys repeatedly to aid grepping.
     let result = {
       type: 'tld',
       title: data.result.title,
@@ -38,7 +39,7 @@ TLDTransform.prototype = {
     return result;
   },
   isValid: function(data) {
-    let valid;
+    let valid = false;
     // Just try to access every required key. If one is missing, the thrown Error
     // will tell us it's an invalid data object. For optional keys, just check
     // that the parent key exists (if no other check touches the parent).
@@ -48,7 +49,7 @@ TLDTransform.prototype = {
                 data.enhancements.favicon.color &&
                 data.enhancements.tld;
     } catch (ex) {}
-    return !!valid;
+    return valid;
   }
 };
 

--- a/lib/tld-transform.js
+++ b/lib/tld-transform.js
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const EXPORTED_SYMBOLS = ['tldTransform'];
+
+const IMAGE_DIMENSION = 32;
+
+function TLDTransform() {
+  /*
+  Class that normalizes the top-level domain type API responses into a data
+  object containing all required keys. Used by the Recommendation to generate a
+  uniform data object to pass into the RecommendationRow for rendering into the
+  XUL DOM.
+
+  This class is stateless, so a singleton instance is created and exported.
+  */
+}
+TLDTransform.prototype = {
+  transform: function(data) {
+    if (!this.isValid(data)) {
+      return;
+    }
+    let result = {
+      type: 'tld',
+      title: data.result.title,
+      url: data.result.url,
+      favicon: {
+        url: data.enhancements.favicon.url || 'chrome://mozapps/skin/places/defaultFavicon@2x.png',
+        color: data.enhancements.favicon.color
+      },
+      keyImage: {
+        url: `${data.enhancements.tld}?size=${IMAGE_DIMENSION * 2}`,
+        height: IMAGE_DIMENSION,
+        width: IMAGE_DIMENSION
+      }
+    };
+    return result;
+  },
+  isValid: function(data) {
+    let valid;
+    // Just try to access every required key. If one is missing, the thrown Error
+    // will tell us it's an invalid data object. For optional keys, just check
+    // that the parent key exists (if no other check touches the parent).
+    try {
+      valid = data.result.title &&
+                data.result.url &&
+                data.enhancements.favicon.color &&
+                data.enhancements.tld;
+    } catch (ex) {}
+    return !!valid;
+  }
+};
+
+const tldTransform = new TLDTransform();

--- a/lib/ui/recommendation-row.js
+++ b/lib/ui/recommendation-row.js
@@ -6,15 +6,6 @@ const EXPORTED_SYMBOLS = ['RecommendationRow'];
 
 const COLORS = ['orange', 'lightorange', 'magenta', 'purple', 'green', 'red',
                 'blue', 'teal', 'grey'];
-const FAVICON = {
-  DEFAULT: 'chrome://mozapps/skin/places/defaultFavicon@2x.png',
-  WIKIPEDIA: 'chrome://universalsearch-skin/content/wikipedia-dark.svg'
-};
-const IMAGE_DIMENSION = 32;
-const TYPES = {
-  TLD: 'tld',
-  WIKIPEDIA: 'wikipedia'
-};
 
 
 function RecommendationRow(data, opts) {
@@ -27,8 +18,9 @@ function RecommendationRow(data, opts) {
   this.eTLD = opts.eTLD;
   this.io = opts.io;
   this._data = data;
-  this._get = this._get.bind(this);
-  this.resultType = this.getResultType(this);
+  this.resultType = this._data.type;
+  this.url = this._unescape(this._data.url);
+  this.el = null;
 }
 
 
@@ -50,23 +42,13 @@ RecommendationRow.prototype = {
       row.renderContent,
       row.renderLabel
     ];
-    let elem = createElement(this.doc, 'hbox', 'container');
-    elem.setAttribute('data-result-type', row.resultType);
+    this.el = createElement(this.doc, 'hbox', 'container');
+    this.el.setAttribute('data-result-type', row.resultType);
+    this.el.classList.add(row.resultType);
     renderMethods.forEach(method => {
-      elem.appendChild(method(row));
+      this.el.appendChild(method(row));
     });
-    return elem;
-  },
-
-  getResultType: function(row) {
-  /*
-  Determines and returns a TYPES property indicating the result type.
-  */
-    if (row._get('enhancements.tld')) {
-      return TYPES.TLD;
-    } else if (row._get('enhancements.wikipedia')) {
-      return TYPES.WIKIPEDIA;
-    }
+    return this.el;
   },
 
   renderFavicon: function(row) {
@@ -75,13 +57,7 @@ RecommendationRow.prototype = {
     available, or if the URL returned from the server errors, will use
     Firefox's default favicon.
     */
-    let favicon;
-    if (row.resultType == TYPES.WIKIPEDIA) {
-      favicon = FAVICON.WIKIPEDIA;
-    } else {
-      favicon = row._get('enhancements.favicon.url') || FAVICON.DEFAULT;
-    }
-
+    let favicon = row._data.favicon.url;
     let wrapper = createElement(row.doc, 'vbox', 'icon');
     let elem = createElement(row.doc, 'image', 'favicon');
     wrapper.appendChild(elem);
@@ -105,68 +81,37 @@ RecommendationRow.prototype = {
   renderImage: function(row) {
     /*
     Creates and returns a <vbox> element containing an image-type
-    representation of the recommendation. If a logo (from Clearbit) is
-    available, use that. If not, but a key image (from Embedly) is available,
-    use that. Otherwise, use a letterbox.
+    representation of the recommendation. Render a key image, if available;
+    otherwise, use a letterbox.
     */
-    let logo = row._get('enhancements.tld');
-    let keyImage = row._get('enhancements.wikipedia.image');
     let elem = createElement(row.doc, 'vbox', 'image');
-    if (logo) {
-      elem.appendChild(row.renderLogo(row, logo));
-    } else if (keyImage) {
-      elem.appendChild(row.renderKeyImage(row, keyImage));
+    if (row._data.keyImage.url) {
+      elem.appendChild(row.renderKeyImage(row, row._data.keyImage));
     } else {
       return row.renderLetterbox(row);
     }
     return elem;
   },
 
-  renderLogo: function(row, logoUrl) {
-    /*
-    Creates and returns an <image> element representing the logo from Clearbit,
-    sized up to 2x pixel density. If it errors, render a letterbox in its
-    place.
-    */
-    let elem = createElement(row.doc, 'image', 'logo');
-    let clearbitUrl = `${logoUrl}?size=${IMAGE_DIMENSION * 2}`;
-
-    row.win.fetch(clearbitUrl, {
-      mode: 'no-cors'
-    }).then((response) => {
-      response.blob().then(imgBlob => {
-        let logoImageUrl = row.win.URL.createObjectURL(imgBlob);
-        elem.setAttribute('src', logoImageUrl);
-      });
-    }, (err) => {
-      elem.parentNode.replaceChild(row.renderLetterbox(row), elem);
-    });
-
-    // Note that we return the element before its 'src' is set.
-    return elem;
-  },
-
   renderKeyImage: function(row, keyImage) {
     /*
     Creates and returns an <image> element containing a key image for the
-    recommendation from Embedly, sized so the shorter dimension is
-    IMAGE_DIMENSION pixels, and the other is sized to maintain the image's
-    aspect ratio. If it errors, render a letterbox in its place.
+    recommendation. If loading the image errors, render a letterbox in its
+    place.
     */
     let elem = createElement(row.doc, 'image', 'keyimage');
-    let sizes = row._getKeyImageSizes(keyImage);
 
-    elem.setAttribute('height', sizes.height);
-    elem.style.height = `${sizes.height}px`;
-    elem.setAttribute('width', sizes.width);
-    elem.style.width = `${sizes.width}px`;
+    elem.setAttribute('height', keyImage.height);
+    elem.style.height = `${keyImage.height}px`;
+    elem.setAttribute('width', keyImage.width);
+    elem.style.width = `${keyImage.width}px`;
 
     row.win.fetch(keyImage.url, {
       mode: 'no-cors'
     }).then((response) => {
       response.blob().then(imgBlob => {
-        let keyImageUrl = row.win.URL.createObjectURL(imgBlob);
-        elem.setAttribute('src', keyImageUrl);
+        let keyImageBlobUrl = row.win.URL.createObjectURL(imgBlob);
+        elem.setAttribute('src', keyImageBlobUrl);
       });
     }, (err) => {
       elem.parentNode.replaceChild(row.renderLetterbox(row), elem);
@@ -214,11 +159,7 @@ RecommendationRow.prototype = {
     recommendation's title.
     */
     let elem = createElement(row.doc, 'description', 'title');
-    if (row.resultType == TYPES.WIKIPEDIA) {
-      elem.textContent = row._unescape(row._get('enhancements.wikipedia.title'));
-    } else {
-      elem.textContent = row._unescape(row._get('result.title'));
-    }
+    elem.textContent = row._unescape(row._data.title);
     return elem;
   },
 
@@ -228,12 +169,7 @@ RecommendationRow.prototype = {
     recommendation's URL.
     */
     let elem = createElement(row.doc, 'description', 'url');
-    let url;
-    if (row.resultType == TYPES.WIKIPEDIA) {
-      url = row._unescape(row._get('enhancements.wikipedia.url'));
-    } else {
-      url = row._unescape(row._get('result.url'));
-    }
+    let url = row._unescape(row._data.url);
     elem.textContent = url;
     elem.setAttribute('data-url', url);
     return elem;
@@ -248,26 +184,16 @@ RecommendationRow.prototype = {
     return elem;
   },
 
-  _get: function(key) {
-    /*
-    Attempt to return a value from the recommendation data at the passed key
-    string. If not set, falsy, or an empty object, return null;
-    */
-    const val = key.split('.').reduce(function(o, x) {
-      return (typeof o == 'undefined' || o === null) ? o : o[x];
-    }, this._data);
-    let isEmptyObject = val => {
-      return val && typeof val == 'object' && !Object.keys(val).length;
-    };
-    return (typeof val == 'undefined' || !val || isEmptyObject(val)) ? null : val;
-  },
-
   _firstLetterInBaseDomain: function(row) {
     /*
     Returns the first letter of the base domain for the passed row.
     */
-    let url = row._get('result.url');
-    return row.eTLD.getBaseDomain(row.io.newURI(url, null, null))[0];
+    let url = row._data.url;
+    let firstLetter;
+    try {
+      firstLetter = row.eTLD.getBaseDomain(row.io.newURI(url, null, null))[0];
+    } catch (ex) {}
+    return firstLetter;
   },
 
   _getLetterboxColors: function(row) {
@@ -279,7 +205,7 @@ RecommendationRow.prototype = {
     favicon. If the brightness of that value is greater than 75%, the
     foreground is black. Otherwise, it is white.
     */
-    let color = row._get('enhancements.favicon.color');
+    let color = row._data.favicon.color;
     if (color) {
       const r = color[0];
       const g = color[1];
@@ -290,25 +216,6 @@ RecommendationRow.prototype = {
         'foreground': brightness > 0.75 ? 'black' : 'white'
       };
     }
-    return;
-  },
-
-  _getKeyImageSizes: function(keyImage) {
-    /*
-    Calculates and returns the display dimensions for the passed key image. The
-    smaller side will be IMAGE_DIMENSION pixels long, while the longer side
-    will be sized to maintain the original image's aspect ratio.
-    */
-    if (keyImage.width > keyImage.height) {
-      return {
-        'width': keyImage.width / keyImage.height * IMAGE_DIMENSION,
-        'height': IMAGE_DIMENSION
-      };
-    }
-    return {
-      'width': IMAGE_DIMENSION,
-      'height': keyImage.height / keyImage.width * IMAGE_DIMENSION
-    };
   },
 
   _getContentMaxWidth: function(row) {

--- a/lib/ui/recommendation-row.js
+++ b/lib/ui/recommendation-row.js
@@ -7,6 +7,7 @@ const EXPORTED_SYMBOLS = ['RecommendationRow'];
 const COLORS = ['orange', 'lightorange', 'magenta', 'purple', 'green', 'red',
                 'blue', 'teal', 'grey'];
 
+const DEFAULT_IMAGE_SIZE = 64;
 
 function RecommendationRow(data, opts) {
   /*
@@ -39,8 +40,7 @@ RecommendationRow.prototype = {
     let renderMethods = [
       row.renderFavicon,
       row.renderImage,
-      row.renderContent,
-      row.renderLabel
+      row.renderContent
     ];
     this.el = createElement(this.doc, 'hbox', 'container');
     this.el.setAttribute('data-result-type', row.resultType);
@@ -48,6 +48,7 @@ RecommendationRow.prototype = {
     renderMethods.forEach(method => {
       this.el.appendChild(method(row));
     });
+
     return this.el;
   },
 
@@ -86,14 +87,14 @@ RecommendationRow.prototype = {
     */
     let elem = createElement(row.doc, 'vbox', 'image');
     if (row._data.keyImage.url) {
-      elem.appendChild(row.renderKeyImage(row, row._data.keyImage));
-    } else {
-      return row.renderLetterbox(row);
+      // Note: the *container* element's height/width are set by renderKeyImage.
+      elem.appendChild(row.renderKeyImage(row, elem, row._data.keyImage));
+      return elem;
     }
-    return elem;
+    return row.renderLetterbox(row);
   },
 
-  renderKeyImage: function(row, keyImage) {
+  renderKeyImage: function(row, parentElem, keyImage) {
     /*
     Creates and returns an <image> element containing a key image for the
     recommendation. If loading the image errors, render a letterbox in its
@@ -106,15 +107,22 @@ RecommendationRow.prototype = {
     elem.setAttribute('width', keyImage.width);
     elem.style.width = `${keyImage.width}px`;
 
+    // Note: in both the resolve() and reject() callbacks, elem.parentNode
+    // is assumed to exist. This is correct, because `elem` is returned and
+    // appended to the XUL DOM before the promise resolves.
     row.win.fetch(keyImage.url, {
       mode: 'no-cors'
     }).then((response) => {
       response.blob().then(imgBlob => {
         let keyImageBlobUrl = row.win.URL.createObjectURL(imgBlob);
         elem.setAttribute('src', keyImageBlobUrl);
+        elem.parentNode.style.height = `${keyImage.height}px`;
+        elem.parentNode.style.width = `${keyImage.width}px`;
       });
     }, (err) => {
       elem.parentNode.replaceChild(row.renderLetterbox(row), elem);
+      elem.parentNode.style.height = `${DEFAULT_IMAGE_SIZE}px`;
+      elem.parentNode.style.width = `${DEFAULT_IMAGE_SIZE}px`;
     });
 
     // Note that we return the element before its 'src' is set.
@@ -143,44 +151,88 @@ RecommendationRow.prototype = {
 
   renderContent: function(row) {
     /*
-    Creates and returns a <vbox> element containing the recommendation's title
-    and URL.
+    Creates and returns three <hbox> elements containing:
+    - the title and the 'Recommended' label (so that description text flows
+      uninterruptedly beneath both)
+    - the details/description (if any)
+    - the url
     */
     let elem = createElement(row.doc, 'vbox', 'content');
-    elem.appendChild(row.renderTitle(row));
+
+    let topRow = createElement(row.doc, 'hbox', 'top-content');
+    topRow.appendChild(row.renderTitle(row));
+    topRow.style.width = '100%';
+
+    let spacer = createElement(row.doc, 'spacer', 'spacer');
+    spacer.setAttribute('flex', 1);
+    topRow.appendChild(spacer);
+
+    topRow.appendChild(row.renderRecommendedLabel(row));
+    elem.appendChild(topRow);
+
+    if (row._data.details) {
+      elem.appendChild(row.renderDetails(row));
+    }
+    if (row._data.description) {
+      elem.appendChild(row.renderDescription(row));
+    }
+
     elem.appendChild(row.renderUrl(row));
+
     elem.style.maxWidth = `${row._getContentMaxWidth(row)}px`;
     return elem;
   },
 
   renderTitle: function(row) {
     /*
-    Creates and returns an <description> element containing the
+    Creates and returns a <label> element containing the
     recommendation's title.
     */
-    let elem = createElement(row.doc, 'description', 'title');
-    elem.textContent = row._unescape(row._data.title);
+    let elem = createElement(row.doc, 'label', 'title');
+    // Use value attribute, not textContent, to avoid wrapping.
+    elem.setAttribute('value', row._unescape(row._data.title));
+    return elem;
+  },
+
+  renderDetails: function(row) {
+    /*
+    Creates and returns a <description> element containing details about
+    the recommended URL.
+    */
+    let elem = createElement(row.doc, 'description', 'details');
+    elem.textContent = row._unescape(row._data.details);
+    return elem;
+  },
+
+  renderDescription: function(row) {
+    /*
+    Creates and returns a <description> element containing a paragraph-length
+    description of the recommendation.
+    */
+    let elem = createElement(row.doc, 'description', 'description');
+    elem.textContent = row._unescape(row._data.description);
     return elem;
   },
 
   renderUrl: function(row) {
     /*
-    Creates and returns an <description> element containing the
+    Creates and returns a <label> element containing the
     recommendation's URL.
     */
-    let elem = createElement(row.doc, 'description', 'url');
+    let elem = createElement(row.doc, 'label', 'url');
     let url = row._unescape(row._data.url);
-    elem.textContent = url;
+    elem.setAttribute('value', url);
     elem.setAttribute('data-url', url);
     return elem;
   },
 
-  renderLabel: function(row) {
+  renderRecommendedLabel: function(row) {
     /*
     Creates and returns an <hbox> element containing the "Recommended" label.
     */
-    let elem = createElement(row.doc, 'hbox', 'label');
-    elem.textContent = 'Recommended';
+    let elem = createElement(row.doc, 'label', 'label');
+    // Set the text as value attribute, not textContent, to avoid wrapping.
+    elem.setAttribute('value', 'Recommended');
     return elem;
   },
 
@@ -243,7 +295,7 @@ RecommendationRow.prototype = {
     that there are at least 200px available for it.
     */
     const MIN = 200;
-    const MAGIC = 197;
+    const MAGIC = 107;
     const popupWidth = Math.floor(
       row.doc.getElementById('PopupAutoCompleteRichResult').width);
     const available = popupWidth - MAGIC;

--- a/lib/ui/recommendation.js
+++ b/lib/ui/recommendation.js
@@ -19,16 +19,20 @@ function Recommendation(opts) {
   this.io = opts.io;
   this.objectUtils = opts.objectUtils;
   this.RecommendationRow = opts.RecommendationRow;
+  this.transforms = {
+    tld: opts.tldTransform,
+    wikipedia: opts.wikipediaTransform
+  };
 
   this.el = null;
-  this.timeout = null;
+  this.hideTimeout = null;
   this.mouseMoveTimeout = null;
-  this.prev = null;
+  // this.rawData is the raw response data from the server.
+  this.rawData = null;
+  // this.data is the data after its type is inferred and it is transformed.
+  this.data = null;
   this.row = null;
   this.searchResults = null;
-  // this.recData is used for duplicate checking, but sort of overlaps with
-  // this.prev / this.data. Consider just storing the data in one place.
-  this.recData = null;
   this.searchController = null;
 
   Object.defineProperty(this, 'isHighlighted', {
@@ -140,7 +144,6 @@ Recommendation.prototype = {
     this.events.publish('recommendation-mouseleave', evt);
   },
   onMouseMove: function(evt) {
-
     // Throttle mousemove events so they fire immediately, then no more often
     // than every 30 ms (may be longer than 30 ms due to event loop delays).
     if (this.mouseMoveTimeout) {
@@ -153,55 +156,68 @@ Recommendation.prototype = {
 
     this.events.publish('recommendation-mousemove', evt);
   },
-  show: function(data) {
-    if (this.timeout) {
-      this.win.clearTimeout(this.timeout);
-      this.timeout = null;
+  show: function() {
+    if (this.hideTimeout) {
+      this.win.clearTimeout(this.hideTimeout);
+      this.hideTimeout = null;
     }
 
-    // Don't re-render the recommendation if the content hasn't changed since
-    // the previous recommendation.
-    if (this.prev && this.el && this.el.firstChild && data.result.url === this.prev.result.url) {
+    if (!this.el) {
+      return;
+    }
+
+    // Reuse the recommendation if it's still in the DOM and the content hasn't
+    // changed since the previous recommendation.
+    if (this.el.firstChild && this.data && this.row.url === this.data.url) {
       this.el.collapsed = false;
       this.events.publish('recommendation-shown', this);
       return;
     }
 
-    this.prev = data;
-    const recommendation = this.row = new this.RecommendationRow(data, {
+    this.row = new this.RecommendationRow(this.data, {
       eTLD: this.eTLD,
       io: this.io,
       win: this.win
-    }).render();
-    if (this.el) {
-      if (recommendation) {
-        if (this.el.firstChild) {
-          this.el.replaceChild(recommendation, this.el.firstChild);
-        } else {
-          this.el.appendChild(recommendation);
-        }
-        this.el.collapsed = false;
-        this.data = data;
-        this.events.publish('recommendation-shown', this);
-      } else {
-        if (this.el.firstChild) {
-          this.el.removeChild(this.el.firstChild);
-        }
-        this.data = null;
-        this.el.collapsed = true;
-      }
+    });
+    this.row.render();
+
+    if (this.el.firstChild) {
+      this.el.replaceChild(this.row.el, this.el.firstChild);
+    } else {
+      this.el.appendChild(this.row.el);
     }
+    this.el.collapsed = false;
+
+    this.events.publish('recommendation-shown', this);
+  },
+  getResultType: function(data) {
+    /*
+    getResultType contains the rules used to decide if a given data packet
+    should be shown as a TLD or Wikipedia recommendation type.
+    */
+    return ('tld' in data.enhancements) ? 'tld' : 'wikipedia';
   },
   hide: function() {
     if (this.el) {
       const container = this.win.document.getElementById(RECOMMENDATION_ID);
-      this.timeout = this.win.setTimeout(function() {
+      this.hideTimeout = this.win.setTimeout(function() {
         this.el.collapsed = true;
       }.bind(this), 100);
-      this.data = null;
       this.searchResults = null;
-      this.recData = null;
+      this.data = null;
     }
+  },
+  hideImmediate: function() {
+    if (this.hideTimeout) {
+      this.win.clearTimeout(this.hideTimeout);
+      this.hideTimeout = null;
+    }
+    if (this.el.firstChild) {
+      this.el.removeChild(this.el.firstChild);
+    }
+    this.el.collapsed = true;
+    this.data = null;
+    this.row = null;
   },
   navigate: function(evt) {
     // Only navigate if it's a left click.
@@ -222,7 +238,7 @@ Recommendation.prototype = {
     });
   },
   onData: function(data) {
-    this.recData = data;
+    this.rawData = data;
 
     this.duplicateCheck();
   },
@@ -263,22 +279,31 @@ Recommendation.prototype = {
     // duplicates one of the results, using nsIURI as a quick, easy way to
     // normalize and compare URLs.
     //
+    // If there's no duplicate, call this.show() to render the recommendation.
+    // Otherwise, return and nothing will be shown.
+    //
     // Comparison rules:
     // a wikipedia recommendation is a duplicate if a result has the same URL;
     // a top-level domain recommendation is a duplicate if any result is a page
     // from that domain (we only want to show new domains).
+    if (!this.searchResults || !this.rawData) {
+      return;
+    }
 
-    if (!this.searchResults || !this.recData) {
+    let type = this.getResultType(this.rawData);
+    this.data = this.transforms[type].transform(this.rawData);
+    // If the data was malformed, immediately hide any existing recommendation.
+    if (!this.data) {
+      this.hideImmediate();
       return;
     }
 
     let isDuplicate = false;
-    let type = 'tld' in this.recData.enhancements ? 'tld' : 'wikipedia';
 
     let recommendationUri;
     try {
       // newURI throws if the recommendation URL is malformed.
-      recommendationUri = this.io.newURI(this.recData.result.url, null, null);
+      recommendationUri = this.io.newURI(this.data.url, null, null);
     } catch (ex) {
       return;
     }
@@ -324,13 +349,13 @@ Recommendation.prototype = {
       // at the domain.
       // For wikipedia results, use nsIURI.equals() to check for URL equality.
       // If a duplicate is found, immediately exit.
-      if (type === 'tld' && this.eTLD.getBaseDomain(resultUri) === this.eTLD.getBaseDomain(recommendationUri) ||
-          type === 'wikipedia' && resultUri.equals(recommendationUri)) {
+      if (this.data.type === 'tld' && this.eTLD.getBaseDomain(resultUri) === this.eTLD.getBaseDomain(recommendationUri) ||
+          this.data.type === 'wikipedia' && resultUri.equals(recommendationUri)) {
         return;
       }
     }
 
-    this.show(this.recData);
+    this.show();
   },
   _isMozAction: function(/* nsIURI */ uri) {
     return MOZ_ACTION_REGEX.test(uri.asciiSpec);

--- a/lib/ui/recommendation.js
+++ b/lib/ui/recommendation.js
@@ -21,11 +21,12 @@ function Recommendation(opts) {
   this.RecommendationRow = opts.RecommendationRow;
   this.transforms = {
     tld: opts.tldTransform,
-    wikipedia: opts.wikipediaTransform
+    wikipedia: opts.wikipediaTransform,
+    movie: opts.movieTransform
   };
 
   this.el = null;
-  this.hideTimeout = null;
+  this.timeout = null;
   this.mouseMoveTimeout = null;
   // this.rawData is the raw response data from the server.
   this.rawData = null;
@@ -55,6 +56,7 @@ function Recommendation(opts) {
   this.show = this.show.bind(this);
   this.onData = this.onData.bind(this);
   this.hide = this.hide.bind(this);
+  this._hide = this._hide.bind(this);
   this._pollForElement = this._pollForElement.bind(this);
   this.pollController = this.pollController.bind(this);
   this._controllerCheck = this._controllerCheck.bind(this);
@@ -156,23 +158,28 @@ Recommendation.prototype = {
 
     this.events.publish('recommendation-mousemove', evt);
   },
-  show: function() {
-    if (this.hideTimeout) {
-      this.win.clearTimeout(this.hideTimeout);
-      this.hideTimeout = null;
+  show: function(data) {
+    if (this.timeout) {
+      this.win.clearTimeout(this.timeout);
+      this.timeout = null;
     }
 
+    // If the recommendation container element hasn't been found in the XUL DOM
+    // yet, give up. See this._pollForElement() for more docs.
     if (!this.el) {
       return;
     }
 
     // Reuse the recommendation if it's still in the DOM and the content hasn't
     // changed since the previous recommendation.
-    if (this.el.firstChild && this.data && this.row.url === this.data.url) {
+    if (this.el.firstChild && data && this.row &&
+        this.row.url === data.url) {
       this.el.collapsed = false;
       this.events.publish('recommendation-shown', this);
       return;
     }
+
+    this.data = data;
 
     this.row = new this.RecommendationRow(this.data, {
       eTLD: this.eTLD,
@@ -193,31 +200,44 @@ Recommendation.prototype = {
   getResultType: function(data) {
     /*
     getResultType contains the rules used to decide if a given data packet
-    should be shown as a TLD or Wikipedia recommendation type.
+    should be shown as a TLD, movie, or Wikipedia recommendation type.
     */
-    return ('tld' in data.enhancements) ? 'tld' : 'wikipedia';
+    let type;
+    if ('tld' in data.enhancements) {
+      type = 'tld';
+    } else if ('movie' in data.enhancements) {
+      type = 'movie';
+    } else {
+      type = 'wikipedia';
+    }
+    return type;
   },
-  hide: function() {
-    if (this.el) {
-      const container = this.win.document.getElementById(RECOMMENDATION_ID);
-      this.hideTimeout = this.win.setTimeout(function() {
-        this.el.collapsed = true;
-      }.bind(this), 100);
-      this.searchResults = null;
-      this.data = null;
+  // Hide the recommendation after a timeout.
+  // Hide immediately if isImmediate is `true`.
+  hide: function(isImmediate) {
+    this.searchResults = null;
+    this.data = null;
+    this.rawData = null;
+
+    if (!this.el) {
+      return;
+    }
+    if (isImmediate === true) {
+      this._hide();
+    } else {
+      this.timeout = this.win.setTimeout(this._hide, 100);
     }
   },
-  hideImmediate: function() {
-    if (this.hideTimeout) {
-      this.win.clearTimeout(this.hideTimeout);
-      this.hideTimeout = null;
-    }
+  _hide: function() {
+    this.el.collapsed = true;
+    this.win.clearTimeout(this.timeout);
+    this.timeout = null;
+    // We can't save the recommendation in the XUL DOM, because its layout
+    // isn't updated when it's reshown, and the window may have been resized.
+    // This is a workaround, but not quite a fix, for #241.
     if (this.el.firstChild) {
       this.el.removeChild(this.el.firstChild);
     }
-    this.el.collapsed = true;
-    this.data = null;
-    this.row = null;
   },
   navigate: function(evt) {
     // Only navigate if it's a left click.
@@ -283,7 +303,8 @@ Recommendation.prototype = {
     // Otherwise, return and nothing will be shown.
     //
     // Comparison rules:
-    // a wikipedia recommendation is a duplicate if a result has the same URL;
+    // a wikipedia or movie recommendation is a duplicate if a result has the
+    // same URL;
     // a top-level domain recommendation is a duplicate if any result is a page
     // from that domain (we only want to show new domains).
     if (!this.searchResults || !this.rawData) {
@@ -291,10 +312,10 @@ Recommendation.prototype = {
     }
 
     let type = this.getResultType(this.rawData);
-    this.data = this.transforms[type].transform(this.rawData);
+    let data = this.transforms[type].transform(this.rawData);
     // If the data was malformed, immediately hide any existing recommendation.
-    if (!this.data) {
-      this.hideImmediate();
+    if (!data) {
+      this.hide(true);
       return;
     }
 
@@ -303,7 +324,7 @@ Recommendation.prototype = {
     let recommendationUri;
     try {
       // newURI throws if the recommendation URL is malformed.
-      recommendationUri = this.io.newURI(this.data.url, null, null);
+      recommendationUri = this.io.newURI(data.url, null, null);
     } catch (ex) {
       return;
     }
@@ -347,15 +368,16 @@ Recommendation.prototype = {
       // Finally, check for duplicates.
       // For TLD results, the eTLD service should give us a good, cheap guess
       // at the domain.
-      // For wikipedia results, use nsIURI.equals() to check for URL equality.
+      // For movie or wikipedia results, use nsIURI.equals() to check for URL
+      // equality.
       // If a duplicate is found, immediately exit.
-      if (this.data.type === 'tld' && this.eTLD.getBaseDomain(resultUri) === this.eTLD.getBaseDomain(recommendationUri) ||
-          this.data.type === 'wikipedia' && resultUri.equals(recommendationUri)) {
+      if (data.type === 'tld' && this.eTLD.getBaseDomain(resultUri) === this.eTLD.getBaseDomain(recommendationUri) ||
+         (data.type === 'wikipedia' || data.type === 'movie') && resultUri.equals(recommendationUri)) {
         return;
       }
     }
 
-    this.show();
+    this.show(data);
   },
   _isMozAction: function(/* nsIURI */ uri) {
     return MOZ_ACTION_REGEX.test(uri.asciiSpec);

--- a/lib/universal-search.js
+++ b/lib/universal-search.js
@@ -152,6 +152,8 @@ Search.prototype = {
     Cu.import('chrome://universalsearch-lib/content/events.js', win.universalSearch);
     Cu.import('chrome://universalsearch-lib/content/metrics.js', win.universalSearch);
     Cu.import('chrome://universalsearch-lib/content/recommendation-server.js', win.universalSearch);
+    Cu.import('chrome://universalsearch-lib/content/tld-transform.js', win.universalSearch);
+    Cu.import('chrome://universalsearch-lib/content/wikipedia-transform.js', win.universalSearch);
 
     Cu.import('chrome://universalsearch-ui/content/highlight-manager.js', win.universalSearch);
     Cu.import('chrome://universalsearch-ui/content/popup.js', win.universalSearch);
@@ -169,6 +171,8 @@ Search.prototype = {
     Cu.unload('chrome://universalsearch-ui/content/recommendation-row.js', win.universalSearch);
     Cu.unload('chrome://universalsearch-ui/content/urlbar.js', win.universalSearch);
 
+    Cu.unload('chrome://universalsearch-lib/content/wikipedia-transform.js', win.universalSearch);
+    Cu.unload('chrome://universalsearch-lib/content/tld-transform.js', win.universalSearch);
     Cu.unload('chrome://universalsearch-lib/content/recommendation-server.js', win.universalSearch);
     Cu.unload('chrome://universalsearch-lib/content/metrics.js', win.universalSearch);
     Cu.unload('chrome://universalsearch-lib/content/events.js', win.universalSearch);
@@ -204,7 +208,9 @@ Search.prototype = {
       io: Services.io,
       objectUtils: ObjectUtils,
       win: win,
-      RecommendationRow: app.RecommendationRow
+      RecommendationRow: app.RecommendationRow,
+      tldTransform: app.tldTransform,
+      wikipediaTransform: app.wikipediaTransform
     });
     app.recommendation.init();
 

--- a/lib/universal-search.js
+++ b/lib/universal-search.js
@@ -40,6 +40,10 @@ Search.prototype = {
   },
 
   unload: function() {
+    // Scripts only need to be unloaded once, globally.
+    this._unloadScripts();
+
+    // The running code and styles must be removed from each window.
     WindowWatcher.stop();
   },
 
@@ -62,7 +66,6 @@ Search.prototype = {
     // to be defined, while _stopApp deletes `win.universalSearch`.
     this._restoreSearchBar(win);
     this._stopApp(win);
-    this._unloadScripts(win);
     this._unloadStyleSheets(win);
 
     // Delete any remaining references.
@@ -160,6 +163,9 @@ Search.prototype = {
   _unloadScripts: function(win) {
     // Unload scripts from the namespace. Not clear on whether this is necessary
     // if we just delete win.universalSearch.
+
+    // NOTE: ONLY unload scripts that are packaged inside this addon (#268).
+    // NEVER unload scripts used globally by Firefox.
     Cu.unload('chrome://universalsearch-ui/content/highlight-manager.js', win.universalSearch);
     Cu.unload('chrome://universalsearch-ui/content/popup.js', win.universalSearch);
     Cu.unload('chrome://universalsearch-ui/content/recommendation.js', win.universalSearch);
@@ -172,9 +178,6 @@ Search.prototype = {
     Cu.unload('chrome://universalsearch-lib/content/recommendation-server.js', win.universalSearch);
     Cu.unload('chrome://universalsearch-lib/content/metrics.js', win.universalSearch);
     Cu.unload('chrome://universalsearch-lib/content/events.js', win.universalSearch);
-
-    // NOTE: we can't unload Console.jsm until the last console call.
-    // It's unloaded by the caller (the unloadFromWindow method).
   },
 
   _startApp: function(win) {

--- a/lib/universal-search.js
+++ b/lib/universal-search.js
@@ -44,8 +44,6 @@ Search.prototype = {
   },
 
   loadIntoWindow: function(win) {
-    console.log('loadIntoWindow start');
-
     // Sets the app global per window.
     win.universalSearch = win.universalSearch || {}
 
@@ -56,11 +54,9 @@ Search.prototype = {
     this._loadScripts(win);
     this._startApp(win);
 
-    console.log('loadIntoWindow finish');
   },
 
   unloadFromWindow: function(win) {
-    console.log('unloadFromWindow start');
 
     // NOTE: order matters here: _restoreSearchBar needs `win.universalSearch`
     // to be defined, while _stopApp deletes `win.universalSearch`.
@@ -71,8 +67,6 @@ Search.prototype = {
 
     // Delete any remaining references.
     delete win.universalSearch;
-
-    console.log('unloadFromWindow finish');
   },
 
   _initializePrefs: function() {
@@ -152,6 +146,7 @@ Search.prototype = {
     Cu.import('chrome://universalsearch-lib/content/events.js', win.universalSearch);
     Cu.import('chrome://universalsearch-lib/content/metrics.js', win.universalSearch);
     Cu.import('chrome://universalsearch-lib/content/recommendation-server.js', win.universalSearch);
+    Cu.import('chrome://universalsearch-lib/content/movie-transform.js', win.universalSearch);
     Cu.import('chrome://universalsearch-lib/content/tld-transform.js', win.universalSearch);
     Cu.import('chrome://universalsearch-lib/content/wikipedia-transform.js', win.universalSearch);
 
@@ -173,6 +168,7 @@ Search.prototype = {
 
     Cu.unload('chrome://universalsearch-lib/content/wikipedia-transform.js', win.universalSearch);
     Cu.unload('chrome://universalsearch-lib/content/tld-transform.js', win.universalSearch);
+    Cu.unload('chrome://universalsearch-lib/content/movie-transform.js', win.universalSearch);
     Cu.unload('chrome://universalsearch-lib/content/recommendation-server.js', win.universalSearch);
     Cu.unload('chrome://universalsearch-lib/content/metrics.js', win.universalSearch);
     Cu.unload('chrome://universalsearch-lib/content/events.js', win.universalSearch);
@@ -210,7 +206,8 @@ Search.prototype = {
       win: win,
       RecommendationRow: app.RecommendationRow,
       tldTransform: app.tldTransform,
-      wikipediaTransform: app.wikipediaTransform
+      wikipediaTransform: app.wikipediaTransform,
+      movieTransform: app.movieTransform
     });
     app.recommendation.init();
 

--- a/lib/wikipedia-transform.js
+++ b/lib/wikipedia-transform.js
@@ -65,7 +65,7 @@ WikipediaTransform.prototype = {
     };
   },
   isValid: function(data) {
-    let valid;
+    let valid = false;
     // Just try to access every required key. If one is missing, the thrown Error
     // will tell us it's an invalid data object. For optional keys, just check
     // that the parent key exists (if no other check touches the parent).
@@ -75,7 +75,7 @@ WikipediaTransform.prototype = {
               data.enhancements.wikipedia.url &&
               data.enhancements.wikipedia.image;
     } catch (ex) {}
-    return !!valid;
+    return valid;
   }
 };
 

--- a/lib/wikipedia-transform.js
+++ b/lib/wikipedia-transform.js
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const EXPORTED_SYMBOLS = ['wikipediaTransform'];
+
+const IMAGE_DIMENSION = 32;
+
+function WikipediaTransform() {
+  /*
+  Class that normalizes the wikipedia type API responses into a data object
+  containing all required keys. Used by the Recommendation to generate a
+  uniform data object to pass into the RecommendationRow for rendering into the
+  XUL DOM.
+
+  This class is stateless, so a singleton instance is created and exported.
+  */
+}
+WikipediaTransform.prototype = {
+  transform: function(data) {
+    if (!this.isValid(data)) {
+      return;
+    }
+    let dimensions = {};
+    if (data.enhancements.wikipedia.image.height &&
+        data.enhancements.wikipedia.image.width) {
+      dimensions = this.calculateDimensions(data);
+    }
+    // NOTE: using the full keys repeatedly to aid grepping.
+    let result = {
+      type: 'wikipedia',
+      favicon: {
+        url: 'chrome://universalsearch-skin/content/wikipedia-dark.svg',
+        color: data.enhancements.favicon.color
+      },
+      title: data.enhancements.wikipedia.title,
+      url: data.enhancements.wikipedia.url,
+      keyImage: {
+        url: data.enhancements.wikipedia.image.url,
+        height: dimensions.height,
+        width: dimensions.width
+      }
+    };
+    return result;
+  },
+  calculateDimensions: function(data) {
+    /*
+    Calculates and returns the display dimensions for the passed key image. The
+    smaller side will be IMAGE_DIMENSION pixels long, while the longer side
+    will be sized to maintain the original image's aspect ratio.
+    */
+    let height = data.enhancements.wikipedia.image.height;
+    let width = data.enhancements.wikipedia.image.width;
+
+    if (width > height) {
+      return {
+        width: width / height * IMAGE_DIMENSION,
+        height: IMAGE_DIMENSION
+      };
+    }
+
+    return {
+      width: IMAGE_DIMENSION,
+      height: height / width * IMAGE_DIMENSION
+    };
+  },
+  isValid: function(data) {
+    let valid;
+    // Just try to access every required key. If one is missing, the thrown Error
+    // will tell us it's an invalid data object. For optional keys, just check
+    // that the parent key exists (if no other check touches the parent).
+    try {
+      valid = data.enhancements.favicon.color &&
+              data.enhancements.wikipedia.title &&
+              data.enhancements.wikipedia.url &&
+              data.enhancements.wikipedia.image;
+    } catch (ex) {}
+    return !!valid;
+  }
+};
+
+const wikipediaTransform = new WikipediaTransform();


### PR DESCRIPTION
@chuckharmston R?

I had hoped to clean up the commit history before opening this for review, but I've run out of time. Probably best viewed as the unified diff; the individual commits are mostly grouped together well, but there are later bugfix commits that haven't been split and squashed. I'll clean up history before landing.

Points of interest:
- uses a set of transforms to ensure all required keys are in the data object before it's passed to the RecommendationRow to be rendered; this allowed a lot of conditional logic to be trimmed.
- we can trivially add A/B support for the movie card by tweaking the Recommendation's `getResultType` method, which assigns the type to a result before it's transformed. Line 213 of Recommendation.js might become something like `else if ('movie' in data.enhancements && variants.isMovieCardEnabled)`.
- tweak the XUL DOM bits to allow the movie description to flow under the 'Recommended' text. Most of these tweaks were bwinton's suggestions and I dimly understand them ;-)
- It turns out we can't reuse the movie card recommendations because XUL doesn't reflow elements that are removed / reinserted into the XUL DOM. This means that if you see a movie card, resize your browser window, then cause the same card to be shown, it'll have the wrong dimensions. To work around this, we discard the old recommendation at the end of the hide timeout.
- the movie cards are a bit slow to render. I think this is because the movie poster image server is a bit slow. Hopefully this speed issue will go away when the image proxy is deployed.
- The transforms' `isValid` method is pushing simplicity a bit far, but it also provides a kind of proto-schema to help document which keys are required for each type, and writing out the full names of the keys aids grepping.

The one thing that still bugs me is the MAGIC constant; I need to spend some time to make sure the 'Recommended' text is pushed far enough to the right. Suggestions welcome.
