### PR TITLE
Revert "Remove all calls to Cu.unload to fix #267"

### DIFF
--- a/lib/universal-search.js
+++ b/lib/universal-search.js
@@ -66,12 +66,17 @@ Search.prototype = {
     // to be defined, while _stopApp deletes `win.universalSearch`.
     this._restoreSearchBar(win);
     this._stopApp(win);
+    this._unloadScripts(win);
     this._unloadStyleSheets(win);
 
     // Delete any remaining references.
     delete win.universalSearch;
 
     console.log('unloadFromWindow finish');
+
+    // We invoke console.log above, so we cannot safely unload Console.jsm
+    // until this point.
+    Cu.unload('resource://gre/modules/Console.jsm', win.universalSearch);
   },
 
   _initializePrefs: function() {
@@ -157,6 +162,23 @@ Search.prototype = {
     Cu.import('chrome://universalsearch-ui/content/recommendation.js', win.universalSearch);
     Cu.import('chrome://universalsearch-ui/content/recommendation-row.js', win.universalSearch);
     Cu.import('chrome://universalsearch-ui/content/urlbar.js', win.universalSearch);
+  },
+
+  _unloadScripts: function(win) {
+    // Unload scripts from the namespace. Not clear on whether this is necessary
+    // if we just delete win.universalSearch.
+    Cu.unload('chrome://universalsearch-ui/content/highlight-manager.js', win.universalSearch);
+    Cu.unload('chrome://universalsearch-ui/content/popup.js', win.universalSearch);
+    Cu.unload('chrome://universalsearch-ui/content/recommendation.js', win.universalSearch);
+    Cu.unload('chrome://universalsearch-ui/content/recommendation-row.js', win.universalSearch);
+    Cu.unload('chrome://universalsearch-ui/content/urlbar.js', win.universalSearch);
+
+    Cu.unload('chrome://universalsearch-lib/content/recommendation-server.js', win.universalSearch);
+    Cu.unload('chrome://universalsearch-lib/content/metrics.js', win.universalSearch);
+    Cu.unload('chrome://universalsearch-lib/content/events.js', win.universalSearch);
+
+    // NOTE: we can't unload Console.jsm until the last console call.
+    // It's unloaded by the caller (the unloadFromWindow method).
   },
 
   _startApp: function(win) {


### PR DESCRIPTION
Reverts mozilla/universal-search#268

We still need to unload our code to upgrade successfully, but should remove the line that unloads Console.jsm globally 
