### PR TITLE
Don't unload the globally-shared Console.jsm module

### DIFF
--- a/lib/universal-search.js
+++ b/lib/universal-search.js
@@ -73,10 +73,6 @@ Search.prototype = {
     delete win.universalSearch;
 
     console.log('unloadFromWindow finish');
-
-    // We invoke console.log above, so we cannot safely unload Console.jsm
-    // until this point.
-    Cu.unload('resource://gre/modules/Console.jsm', win.universalSearch);
   },
 
   _initializePrefs: function() {


### PR DESCRIPTION
...but do unload all the universal search code, so that we can unload old code as part of the add-on upgrade process.

Fixes #267. @chuckharmston R?
