### PR TITLE
Use A/B testing framework to show movie cards to half of users

### DIFF
--- a/lib/ui/recommendation.js
+++ b/lib/ui/recommendation.js
@@ -19,6 +19,7 @@ function Recommendation(opts) {
   this.io = opts.io;
   this.objectUtils = opts.objectUtils;
   this.RecommendationRow = opts.RecommendationRow;
+  this.useMovieCard = opts.useMovieCard;
   this.transforms = {
     tld: opts.tldTransform,
     wikipedia: opts.wikipediaTransform,
@@ -201,11 +202,14 @@ Recommendation.prototype = {
     /*
     getResultType contains the rules used to decide if a given data packet
     should be shown as a TLD, movie, or Wikipedia recommendation type.
+
+    The movie card is only shown to a fraction of users; the Test Pilot add-on
+    selects which users are in which group.
     */
     let type;
     if ('tld' in data.enhancements) {
       type = 'tld';
-    } else if ('movie' in data.enhancements) {
+    } else if (this.useMovieCard && 'movie' in data.enhancements) {
       type = 'movie';
     } else {
       type = 'wikipedia';

--- a/lib/universal-search.js
+++ b/lib/universal-search.js
@@ -5,6 +5,8 @@
 const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 
 Cu.import('resource://gre/modules/XPCOMUtils.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'clearTimeout',
+  'resource://gre/modules/Timer.jsm');
 XPCOMUtils.defineLazyModuleGetter(this, 'console',
   'resource://gre/modules/Console.jsm');
 XPCOMUtils.defineLazyModuleGetter(this, 'CustomizableUI',
@@ -15,6 +17,8 @@ XPCOMUtils.defineLazyModuleGetter(this, 'PrivateBrowsingUtils',
   'resource://gre/modules/PrivateBrowsingUtils.jsm');
 XPCOMUtils.defineLazyModuleGetter(this, 'Services',
   'resource://gre/modules/Services.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'setTimeout',
+  'resource://gre/modules/Timer.jsm');
 XPCOMUtils.defineLazyModuleGetter(this, 'WindowWatcher',
   'chrome://universalsearch-lib/content/window-watcher.js');
 
@@ -27,16 +31,79 @@ function Search() {
   uninstalled. It's invoked by the bootstrap.js file.
   */
 
+  this.variants = null;
+  this.variantTimeout = null;
+
   // Due to limitations in passing objects between window contexts, we have to
   // bind the callbacks passed to WindowWatcher.start().
   this.loadIntoWindow = this.loadIntoWindow.bind(this);
   this.unloadFromWindow = this.unloadFromWindow.bind(this);
   this.onError = this.onError.bind(this);
+  this._load = this._load.bind(this);
 }
 
 Search.prototype = {
   load: function() {
+    this.fetchVariantData(this._load);
+  },
+
+  _load: function() {
     WindowWatcher.start(this.loadIntoWindow, this.unloadFromWindow, this.onError);
+  },
+
+  fetchVariantData: function(cb) {
+    const PING_DELAY = 1000;
+
+    // For the moment, declare tests inline.
+    const tests = {
+      movieCard: {
+        name: 'Movie card test',
+        description: 'Test engagement with and without a separate movie recommendation',
+        variants: [
+          { description: 'show movie cards', value: true, weight: 1 },
+          { description: 'do not show movie cards', value: false, weight: 1 }
+        ]
+      }
+    };
+
+    const variantObserver = {
+      observe: function(subject, topic, data) {
+        try {
+          this.variants = data && data.data && JSON.parse(data.data);
+        } catch (ex) {
+          console.error('testpilot::receive-variants message parsing error: ', ex);
+        }
+
+        if (this.variants) {
+          Services.obs.removeObserver('testpilot::receive-variants', variantObserver);
+          clearTimeout(this.variantTimeout);
+          cb();
+        }
+      }
+    };
+    variantObserver.observe = variantObserver.observe.bind(this);
+    Services.obs.addObserver('testpilot::receive-variants', variantObserver);
+
+    // Poll the Test Pilot add-on until the 'testpilot::receive-variants'
+    // observer assigns a truthy value to `this.variants`.
+    let sendPing = function() {
+      if (this.variants) {
+        return;
+      }
+
+      // This looks strange, but it's required to send over the test ID.
+      const subject = {
+        wrappedJSObject: {
+          observersModuleSubjectWrapper: true,
+          object: 'universal-search@mozilla.com'
+        }
+      };
+      Services.obs.notifyObservers(subject, 'testpilot::register-variants', JSON.stringify(tests));
+
+      this.variantTimeout = setTimeout(sendPing, PING_DELAY);
+    };
+    sendPing = sendPing.bind(this);
+    sendPing();
   },
 
   unload: function() {
@@ -210,7 +277,8 @@ Search.prototype = {
       RecommendationRow: app.RecommendationRow,
       tldTransform: app.tldTransform,
       wikipediaTransform: app.wikipediaTransform,
-      movieTransform: app.movieTransform
+      movieTransform: app.movieTransform,
+      useMovieCard: app.variants.movieCard
     });
     app.recommendation.init();
 


### PR DESCRIPTION
@chuckharmston R?

Summary of changes:
- fetch variant data before initializing the app
- pass the data into the ui/recommendation
- use variant data to toggle whether movie cards are displayed; see `getResultType` in `lib/ui/recommendation.js` for the very simple implementation details

Still need to verify that this works with the latest Test Pilot add-on.
