### PR TITLE
Only unload scripts once

### DIFF
--- a/lib/universal-search.js
+++ b/lib/universal-search.js
@@ -40,6 +40,10 @@ Search.prototype = {
   },
 
   unload: function() {
+    // Scripts only need to be unloaded once, globally.
+    this._unloadScripts();
+
+    // The running code and styles must be removed from each window.
     WindowWatcher.stop();
   },
 
@@ -66,7 +70,6 @@ Search.prototype = {
     // to be defined, while _stopApp deletes `win.universalSearch`.
     this._restoreSearchBar(win);
     this._stopApp(win);
-    this._unloadScripts(win);
     this._unloadStyleSheets(win);
 
     // Delete any remaining references.
@@ -160,21 +163,21 @@ Search.prototype = {
     Cu.import('chrome://universalsearch-ui/content/urlbar.js', win.universalSearch);
   },
 
-  _unloadScripts: function(win) {
+  _unloadScripts: function() {
     // Unload scripts from the namespace. Not clear on whether this is necessary
     // if we just delete win.universalSearch.
-    Cu.unload('chrome://universalsearch-ui/content/highlight-manager.js', win.universalSearch);
-    Cu.unload('chrome://universalsearch-ui/content/popup.js', win.universalSearch);
-    Cu.unload('chrome://universalsearch-ui/content/recommendation.js', win.universalSearch);
-    Cu.unload('chrome://universalsearch-ui/content/recommendation-row.js', win.universalSearch);
-    Cu.unload('chrome://universalsearch-ui/content/urlbar.js', win.universalSearch);
 
-    Cu.unload('chrome://universalsearch-lib/content/recommendation-server.js', win.universalSearch);
-    Cu.unload('chrome://universalsearch-lib/content/metrics.js', win.universalSearch);
-    Cu.unload('chrome://universalsearch-lib/content/events.js', win.universalSearch);
+    // NOTE: ONLY unload scripts that are packaged inside this addon (#268).
+    // NEVER unload scripts used globally by Firefox.
+    Cu.unload('chrome://universalsearch-ui/content/highlight-manager.js');
+    Cu.unload('chrome://universalsearch-ui/content/popup.js');
+    Cu.unload('chrome://universalsearch-ui/content/recommendation.js');
+    Cu.unload('chrome://universalsearch-ui/content/recommendation-row.js');
+    Cu.unload('chrome://universalsearch-ui/content/urlbar.js');
 
-    // NOTE: we can't unload Console.jsm until the last console call.
-    // It's unloaded by the caller (the unloadFromWindow method).
+    Cu.unload('chrome://universalsearch-lib/content/recommendation-server.js');
+    Cu.unload('chrome://universalsearch-lib/content/metrics.js');
+    Cu.unload('chrome://universalsearch-lib/content/events.js');
   },
 
   _startApp: function(win) {


### PR DESCRIPTION
Cu.unload unloads scripts globally. No need to unload per-window.

Fixes #276.

This is a cleanup bugfix, not a user-visible bug fix, but I'd still like to retain it after reverting the movie card PR. Not going to rev the version number, though, as it doesn't merit a release.

@chuckharmston R?
