### PR TITLE
Disable one-off search buttons and simplify popup initialization

### DIFF
--- a/chrome/content/binding.xml
+++ b/chrome/content/binding.xml
@@ -19,11 +19,18 @@
         <children/>
         <xul:vbox anonid="one-off-search-buttons"
                   class="search-one-offs"
+                  hidden="true"
                   compact="true"
                   includecurrentengine="true"
+                  disabletab="true"
                   flex="1"/>
       </xul:hbox>
     </content>
+    <implementation>
+      <constructor><![CDATA[
+        this.mInput = window.gURLBar;
+      ]]></constructor>
+    </implementation>
   </binding>
 
   <![CDATA[

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -26,8 +26,8 @@ function Metrics(opts) {
 
 Metrics.prototype = {
   init: function() {
-    // Start listening when the popup is about to open.
-    this.events.subscribe('before-popup-show', this.interactionStart);
+    // Start listening when the popup has just opened.
+    this.events.subscribe('after-popup-shown', this.interactionStart);
 
     // Detect when a navigation event occurs.
     this.events.subscribe('before-keyboard-navigate', this.onKeyNavigate);
@@ -40,7 +40,7 @@ Metrics.prototype = {
     this.events.subscribe('after-popup-hide', this.interactionEnd);
   },
   destroy: function() {
-    this.events.unsubscribe('before-popup-show', this.interactionStart);
+    this.events.unsubscribe('after-popup-shown', this.interactionStart);
     this.events.unsubscribe('before-keyboard-navigate', this.onKeyNavigate);
     this.events.unsubscribe('before-click-navigate', this.onClickNavigate);
     this.events.unsubscribe('urlbar-change', this.interactionStart);

--- a/lib/ui/popup.js
+++ b/lib/ui/popup.js
@@ -15,9 +15,8 @@ function Popup(opts) {
   this.popupOpenObserver = null;
 
   this.afterPopupHide = this.afterPopupHide.bind(this);
-  this.beforePopupShow = this.beforePopupShow.bind(this);
+  this.afterPopupShown = this.afterPopupShown.bind(this);
   this.onResultsMouseMove = this.onResultsMouseMove.bind(this);
-  this.onFirstPopupOpen = this.onFirstPopupOpen.bind(this);
   this.onClick = this.onClick.bind(this);
 }
 
@@ -25,29 +24,12 @@ Popup.prototype = {
   init: function() {
     this.el = this.win.document.getElementById('PopupAutoCompleteRichResult');
     this.el.addEventListener('popuphidden', this.afterPopupHide);
-    this.el.addEventListener('popupshowing', this.beforePopupShow);
+    this.el.addEventListener('popupshown', this.afterPopupShown);
     this.el.addEventListener('click', this.onClick);
-
-    // The first time the popup opens, a bit of popup state is not set
-    // correctly, causing no results to be shown, and causing the popup to fail
-    // to appear more than once (#138). To work around this bug, listen for the
-    // popup to be opened for the first time, and set the missing state.
-    //
-    // (The changes that introduced this bug are large (~1800 lines) and
-    // complex: https://github.com/mozilla/gecko-dev/commit/ee27759c)
-    //
-    // Listen for the popup's first open by using a MutationObserver to detect
-    // a change in the popup element's 'hidden' attribute.
-    this.popupOpenObserver = new this.win.MutationObserver(this.onFirstPopupOpen);
-    let observerConfig = {
-      attributes: true,
-      attributeFilter: ['hidden']
-    };
-    this.popupOpenObserver.observe(this.el, observerConfig);
   },
   destroy: function() {
     this.el.removeEventListener('popuphidden', this.afterPopupHide);
-    this.el.removeEventListener('popupshowing', this.beforePopupShow);
+    this.el.removeEventListener('popupshown', this.afterPopupShown);
     this.el.removeEventListener('click', this.onClick);
 
     this.win.clearTimeout(this.mouseMoveTimeout);
@@ -55,21 +37,11 @@ Popup.prototype = {
     delete this.el;
     delete this.win;
   },
-  onFirstPopupOpen: function(evt) {
-    // The popup is opening for the first time. Set the missing state so that
-    // it works correctly. See also the docs on the MutationObserver created
-    // in the constructor.
-    this.el.mInput = this.win.gURLBar;
-    // The observer is only needed the first time the popup opens per window,
-    // so get rid of it.
-    this.popupOpenObserver.disconnect();
-    this.popupOpenObserver = null;
-  },
   afterPopupHide: function(evt) {
     this.events.publish('after-popup-hide');
   },
-  beforePopupShow: function(evt) {
-    this.events.publish('before-popup-show');
+  afterPopupShown: function(evt) {
+    this.events.publish('after-popup-shown');
   },
   onResultsMouseMove: function(evt) {
     // Throttle mousemove events, which fire rapidly as the user moves

--- a/lib/universal-search.js
+++ b/lib/universal-search.js
@@ -37,11 +37,19 @@ function Search() {
 Search.prototype = {
   load: function() {
     WindowWatcher.start(this.loadIntoWindow, this.unloadFromWindow, this.onError);
+
+    // Disable one-off search.
+    if (Services.prefs.getPrefType('browser.urlbar.oneOffSearches')) {
+      Services.prefs.setBoolPref('browser.urlbar.oneOffSearches', false);
+    }
   },
 
   unload: function() {
     // Scripts only need to be unloaded once, globally.
     this._unloadScripts();
+
+    // Restore the default one-off-search setting.
+    Services.prefs.clearUserPref('browser.urlbar.oneOffSearches');
 
     // The running code and styles must be removed from each window.
     WindowWatcher.stop();


### PR DESCRIPTION
@chuckharmston, @0c0w3, mind taking a look? Commit message continues below:

This commit contains a small cluster of changes that jointly fix #286:

Connecting the urlbar to the popup in an XBL constructor works far
better than the old onFirstPopupOpen approach. This is a better way of
fixing #138, and it resolves the 'maxRows - 1 is undefined' error.

Disabling one-off search by disabling the pref and removing the one-off
search buttons from the XUL DOM (via hidden=true) closes #292,
closes #293, closes #298--but those bugs aren't really fixed, just
hidden. Filed #304 to re-enable one-off search as time allows. Note that
the disabletab attribute was added just to make the set of attributes in
our one-off-search-buttons element match the element in FF.)

Switching our popup.js listener from the 'popupshowing' event to the
'popupshown' event fixes #295, with some cascading changes related to
renaming the function and the signal fired by the function.

\o/
