### PR TITLE
Update urlbar state management to fix Enter key in Nightly

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.12
+
+**Date:** 2016/10/17
+
+**Download:** [`universal-search-1.0.12.xpi`](https://s3-us-west-2.amazonaws.com/universal-search/universal-search-1.0.12.xpi)
+
+**Summary:** Fixes broken Enter key in Nightly ([issue 322](https://github.com/mozilla/universal-search/issues/322)).
+
 ## 1.0.11
 
 **Date:** 2016/10/03

--- a/install.rdf
+++ b/install.rdf
@@ -5,7 +5,7 @@
     <em:bootstrap>true</em:bootstrap>
     <em:type>2</em:type>
     <em:unpack>false</em:unpack>
-    <em:version>1.0.11</em:version>
+    <em:version>1.0.12</em:version>
     <em:name>Universal Search</em:name>
     <em:description>Universal Search puts the best sites from around the web in your Awesome Bar. By typing just a few characters, you can easily navigate to the best the web has to offer. You’ll also find recommendations for popular people and articles from Wikipedia so you can quickly get answers to your burning questions. Learn more about this Test Pilot experiment at https://testpilot.firefox.com. </em:description>
     <em:creator/>

--- a/lib/ui/highlight-manager.js
+++ b/lib/ui/highlight-manager.js
@@ -357,7 +357,11 @@ HighlightManager.prototype = {
 
     // Now that we've figured out which item will take the highlight,
     // update the DOM, and fire a signal that sets the newUrl in the urlbar.
-    this.popup.el.selectedIndex = newIndex;
+    if ('setInitiallySelectedIndex' in this.popup.el.input.controller) {
+      this.popup.el.input.controller.setInitiallySelectedIndex(newIndex);
+    } else {
+      this.popup.el.selectedIndex = newIndex;
+    }
     this.recommendation.isHighlighted = shouldHighlightRecommendation;
     this.events.publish('selection-change', { newUrl: newUrl });
   }

--- a/update.rdf
+++ b/update.rdf
@@ -6,7 +6,7 @@
       <RDF:Seq>
         <RDF:li>
           <RDF:Description>
-            <em:version>1.0.11</em:version>
+            <em:version>1.0.12</em:version>
             <em:targetApplication>
               <RDF:Description>
                 <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>


### PR DESCRIPTION
- Upstream bug 1306639 changed how the urlbar state is set. Update how
  we set urlbar state to work with the new approach.

Fixes #322.

@chuckharmston mind giving this a try? seems to fix the issue for me in nightly, but also keeps things working as usual in dev edition.
