### PR TITLE
Change the update URL

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -13,7 +13,7 @@
     <em:optionsURL>chrome://universalsearch/content/preferences.xul</em:optionsURL>
     <em:iconURL>chrome://universalsearch-skin/content/icon.png</em:iconURL>
     <em:optionsType>2</em:optionsType>
-    <em:updateURL>https://s3-us-west-2.amazonaws.com/universal-search/update.rdf</em:updateURL>
+    <em:updateURL>https://testpilot.firefox.com/files/universalsearch/updates.json</em:updateURL>
     <em:targetApplication>
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>


### PR DESCRIPTION
This is a new update URL.  I'm not changing the one in update.rdf because that file would no longer be in use.  If you r+ this patch, next steps:

1) Make a new add-on version with this URL in it
2) Send new .xpi to clouserw to put on S3
3) Push new add-on version live, people will upgrade it and change their updateURL to s3 (which will have the new version, so it won't upgrade again).
4) Patch testpilot to point to https://testpilot.firefox.com/files/universalsearch/latest for the install links
